### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 
 php:
   - hhvm
+  - 7.3
   - 7.1
   - 7.0
   - 5.6


### PR DESCRIPTION
## Proposed Changes

Once PHP 7.3-beta came out, the `nightly` build on Travis became PHP 7.4-dev and build haven't been tested against PHP 7.3 for months now.

Luckily, Travis has *finally* deemed it appropriate to set up a PHP 7.3 alias now RC3 is out, so I've added  PHP 7.3 to the matrix.

## Related Issues

https://github.com/travis-ci/travis-ci/issues/9717#issuecomment-429564626
