### PR TITLE
Drop support for PHP 5.3

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -29,7 +29,7 @@ jobs:
 
         include:
           # Ensure a "highest" PHP/PHPCS build combination for PHPCS 2.x is included.
-          - php: '5.3'
+          - php: '5.4'
             phpcs_version: '2.9.2'
             phpcompat: 'composer'
             experimental: false
@@ -78,10 +78,6 @@ jobs:
             phpcompat: '^7.0'
             experimental: false
           - php: '5.4'
-            phpcs_version: '2.0.0'
-            phpcompat: '^7.0'
-            experimental: false
-          - php: '5.3'
             phpcs_version: '2.0.0'
             phpcompat: '^7.0'
             experimental: false

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.3', '5.6', '7.2', 'latest']
+        php: ['5.4', '5.6', '7.2', 'latest']
 
     name: "PHP Lint: PHP ${{ matrix.php }}"
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -37,7 +37,7 @@ jobs:
           - php: '5.6'
             phpcs_version: '2.6.0'
             phpcompat: 'composer'
-          - php: '5.3'
+          - php: '5.4'
             phpcs_version: '2.0.0'
             phpcompat: '^7.0'
 

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.3', 'latest']
+        php: ['5.4', 'latest']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ That's it.
 
 This plugin is compatible with:
 
-- PHP **5.x**, **7.x**, and **8.x** (Support for PHP v8 is available since [`v0.7.0`][v0.7])
+- PHP **5.4+**, **7.x**, and **8.x** (Support for PHP v8 is available since [`v0.7.0`][v0.7])
 - [Composer][composer] **1.x** and **2.x** (Support for Composer v2 is available since [`v0.7.0`][v0.7])
 - [PHP_CodeSniffer][codesniffer] **2.x** and **3.x** (Support for PHP_CodeSniffer v3 is available since [`v0.4.0`][v0.4])
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
   },
   "require": {
-    "php": ">=5.3",
+    "php": ">=5.4",
     "composer-plugin-api": "^1.0 || ^2.0",
     "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,10 +13,10 @@
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
     <rule ref="PHPCompatibility"/>
-    <config name="testVersion" value="5.3-"/>
+    <config name="testVersion" value="5.4-"/>
 
     <rule ref="PSR12">
-        <!-- Constant visibility can not be declared (yet) as the minimum supported PHP version is 5.3
+        <!-- Constant visibility can not be declared (yet) as the minimum supported PHP version is 5.4
              and constant visibility was only introduced in PHP 7.1. -->
         <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
     </rule>


### PR DESCRIPTION
## Proposed Changes

This PR just and only drops support for PHP 5.3. It doesn't (yet) take advantage of features which were introduced in PHP 5.4, which could now be used.

## Related Issues

Fixes #145
