### PR TITLE
GH Actions: run integration tests against Composer snapshot

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -41,9 +41,18 @@ jobs:
           - 'ubuntu-latest'
           - 'windows-latest'
 
+        include:
+          - php: 'latest'
+            composer: 'snapshot'
+            os: 'ubuntu-latest'
+
+          - php: 'latest'
+            composer: 'snapshot'
+            os: 'windows-latest'
+
     name: "Integration test"
 
-    continue-on-error: ${{ matrix.php == '8.2' }}
+    continue-on-error: ${{ matrix.php == '8.2' || matrix.composer == 'snapshot' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Proposed Changes

Run integration tests against Composer snapshot for a limited set of builds to get early warning of upcoming changes we need to be aware of.

It has already been announced that Composer 2.3 will drop support for PHP < 7.2 and there may be more breaking changes, so seeing test failures early would seem a good thing (both to fix things in the plugin, if needs be, as well as to report issues with the next version of Composer upstream).

