### PR TITLE
Tests: add new `InvalidPackagesTest`

### DIFF
--- a/tests/IntegrationTest/InvalidPackagesTest.php
+++ b/tests/IntegrationTest/InvalidPackagesTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the Dealerdirect PHP_CodeSniffer Standards
+ * Composer Installer Plugin package.
+ *
+ * @copyright 2022 PHPCodeSniffer Composer Installer Contributors
+ * @license MIT
+ */
+
+namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+
+use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+
+/**
+ * Test that the plugin does not act on packages which are not valid PHPCS standards.
+ *
+ * Valid PHPCS standards for the purposes of this plugin, are packages which:
+ * - have the `phpcodesniffer-standard` type set in their `composer.json` file.
+ * - contain at least one `ruleset.xml` file.
+ *
+ * This test is about Composer and the plugin, so does not need to be tested against multiple PHPCS versions.
+ * The behaviour also shouldn't differ between a global vs local Composer install, so only testing one type.
+ */
+final class InvalidPackagesTest extends TestCase
+{
+    private $composerConfigNoRuleset = array(
+        'name'        => 'phpcs-composer-installer/invalid-package-no-ruleset-test',
+        'require-dev' => array(
+            'squizlabs/php_codesniffer'           => '*',
+            'phpcs-composer-installer/no-ruleset' => '*',
+        ),
+    );
+
+    private $composerConfigIncorrectType = array(
+        'name'        => 'phpcs-composer-installer/invalid-package-incorrect-type-test',
+        'require-dev' => array(
+            'squizlabs/php_codesniffer'               => '*',
+            'phpcs-composer-installer/incorrect-type' => '*',
+        ),
+    );
+
+    /**
+     * Set up test environment before each test.
+     */
+    protected function set_up()
+    {
+        $this->createTestEnvironment();
+    }
+
+    /**
+     * Clean up after each test.
+     */
+    protected function tear_down()
+    {
+        $this->removeTestEnvironment();
+    }
+
+    /**
+     * Test that the plugin does not set the installed_paths for invalid external PHPCS standards.
+     *
+     * @dataProvider dataInvalidPackages
+     *
+     * @param array  $config       The Composer configuration to use.
+     * @param string $standardName The name of the PHPCS standard which is expected to NOT be registered.
+     *
+     * @return void
+     */
+    public function testDontSetInstalledPathsForInvalidPackages($config, $standardName)
+    {
+        $this->writeComposerJsonFile($config, static::$tempLocalPath);
+
+        // Make sure the plugin runs.
+        $this->assertExecute(
+            sprintf('composer install -v --no-ansi --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
+            0,    // Expected exit code.
+            Plugin::MESSAGE_RUNNING_INSTALLER, // Expected stdout.
+            null, // No stderr expectation.
+            'Failed to install dependencies.'
+        );
+
+        // Make sure the CodeSniffer.conf file does not get created when no (valid) external standards are found.
+        $this->assertFileDoesNotExist(
+            static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf'
+        );
+
+        // Make sure that the standard does not show up as registered with PHPCS.
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" -i', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for phpcs -i did not match 0');
+        $this->assertStringNotContainsString(
+            $standardName,
+            $result['stdout'],
+            'Invalid standard registered.'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataInvalidPackages()
+    {
+        return array(
+            'Composer package without ruleset file' => array(
+                'configName'   => $this->composerConfigNoRuleset,
+                'standardName' => 'NoRuleset',
+            ),
+            'Composer package with incorrect type' => array(
+                'configName'   => $this->composerConfigIncorrectType,
+                'standardName' => 'IncorrectType',
+            ),
+        );
+    }
+}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -29,6 +29,8 @@ Notes:
 
 It is recommended to add a short description of the situation which can be tested with each fixture to the below list.
 
+## Valid packages
+
 ### Package name: `phpcs-composer-installer/dummy-subdir`
 
 **Description:**
@@ -62,3 +64,27 @@ An external PHPCS standard with the `ruleset.xml` file in a deeper nested subdir
 | **Includes sniff(s):**   | :x:               |
 | **Requires the plugin:** | :heavy_checkmark: |
 
+
+## Invalid packages
+
+**_These packages should not be installed by the plugin._**
+
+### Package name: `phpcs-composer-installer/no-ruleset`
+
+**Description:**
+A Composer package which has the `phpcodesniffer-standard` type set in the `composer.json` file, but doesn't contain a `ruleset.xml` file (but does contain a `ruleset.xml.dist` file, which is not a file recognized by PHPCS).
+
+| Characteristics          | Notes             |
+|--------------------------|-------------------|
+| **Standard(s):**         | `NoRuleset`       |
+| **Requires the plugin:** | :heavy_checkmark: |
+
+### Package name: `phpcs-composer-installer/incorrect-type`
+
+**Description:**
+An external PHPCS standard which does not have the `phpcodesniffer-standard` type set in the `composer.json` file.
+
+| Characteristics          | Notes             |
+|--------------------------|-------------------|
+| **Standard(s):**         | `IncorrectType`   |
+| **Requires the plugin:** | :heavy_checkmark: |

--- a/tests/fixtures/incorrect-type/IncorrectType/ruleset.xml
+++ b/tests/fixtures/incorrect-type/IncorrectType/ruleset.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="IncorrectType" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <description>Dummy PHPCS standard for testing.</description>
+</ruleset>

--- a/tests/fixtures/incorrect-type/composer.json
+++ b/tests/fixtures/incorrect-type/composer.json
@@ -1,0 +1,16 @@
+{
+    "name" : "phpcs-composer-installer/incorrect-type",
+    "description" : "Dummy PHPCS standard with subdirectory ruleset for use in the tests.",
+    "type" : "coding-standard",
+    "license" : "MIT",
+    "require" : {
+        "php" : ">=5.4",
+        "squizlabs/php_codesniffer" : "*",
+        "dealerdirect/phpcodesniffer-composer-installer" : "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}

--- a/tests/fixtures/no-ruleset/NoRuleset/ruleset.xml.dist
+++ b/tests/fixtures/no-ruleset/NoRuleset/ruleset.xml.dist
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NoRuleset" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+
+    <description>Dummy PHPCS standard for testing.</description>
+</ruleset>

--- a/tests/fixtures/no-ruleset/composer.json
+++ b/tests/fixtures/no-ruleset/composer.json
@@ -1,0 +1,16 @@
+{
+    "name" : "phpcs-composer-installer/no-ruleset",
+    "description" : "Dummy PHPCS standard without a ruleset for use in the tests.",
+    "type" : "phpcodesniffer-standard",
+    "license" : "MIT",
+    "require" : {
+        "php" : ">=5.4",
+        "squizlabs/php_codesniffer" : "*",
+        "dealerdirect/phpcodesniffer-composer-installer" : "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

This new test class tests that the plugin does not act on Composer packages which are not considered valid external PHPCS standards for the purposes of this plugin.

Notes:
* This test is about Composer and the plugin, so does not need to be tested against multiple PHPCS versions.
* The behaviour also shouldn't differ between a global vs local Composer install, so only testing one type.

Related to #92