### PR TITLE
RegisterExternalStandardsTest: stabilize test for Composer v1 on Windows with PHP 5.5

### DIFF
--- a/tests/IntegrationTest/RegisterExternalStandardsTest.php
+++ b/tests/IntegrationTest/RegisterExternalStandardsTest.php
@@ -293,10 +293,11 @@ final class RegisterExternalStandardsTest extends TestCase
         $this->writeComposerJsonFile($config, static::$tempGlobalPath);
 
         // Install the dependencies and verify that the plugin has run.
+        $expectedStdOut = $this->willPluginOutputShow() ? 'PHP CodeSniffer Config installed_paths set to ' : null;
         $this->assertExecute(
             'composer global install -v --no-ansi',
             0,    // Expected exit code.
-            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
+            $expectedStdOut, // Expectation for stdout.
             null, // No stderr expectation.
             'Failed to install dependencies.'
         );


### PR DESCRIPTION
## Proposed Changes

Looks like the build for one of the new PRs is failing on the Composer v1 / Windows / PHP 5.5 build, which is notorious for not always showing the output from the plugin, even though the plugin does work.

This minor change should stabilize that test for that particular build.

Also see: https://github.com/PHPCSStandards/composer-installer/commit/d4f64b822a76e1aac325f18ac160b9daac01ff49
