### PR TITLE
GH Actions: add builds against Composer 2.2 for PHP 7.2 - 8.x

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -42,6 +42,48 @@ jobs:
           - 'windows-latest'
 
         include:
+          # Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install
+          # Composer 2.2, for PHP 7.2 and up, `v2` will install Composer 2.3.
+          # These builds make sure the Composer 2.2 LTS version is 100% supported for PHP 7.2-8.x.
+          - php: '7.2'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+          - php: '7.3'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+          - php: '7.4'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+          - php: '8.0'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+          - php: '8.1'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+          - php: '8.2'
+            composer: '2.2'
+            os: 'ubuntu-latest'
+
+          - php: '7.2'
+            composer: '2.2'
+            os: 'windows-latest'
+          - php: '7.3'
+            composer: '2.2'
+            os: 'windows-latest'
+          - php: '7.4'
+            composer: '2.2'
+            os: 'windows-latest'
+          - php: '8.0'
+            composer: '2.2'
+            os: 'windows-latest'
+          - php: '8.1'
+            composer: '2.2'
+            os: 'windows-latest'
+          - php: '8.2'
+            composer: '2.2'
+            os: 'windows-latest'
+
+          # Also test against the dev version of Composer for early warning about upcoming changes.
           - php: 'latest'
             composer: 'snapshot'
             os: 'ubuntu-latest'

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -114,7 +114,7 @@ if (defined('COMPOSER_PHAR') === false) {
 // Get the version of Composer being used.
 $command  = '"' . \PHP_BINARY . '" "' . \COMPOSER_PHAR . '" --version --no-ansi --no-interaction';
 $lastLine = exec($command, $output, $exitcode);
-if ($exitcode === 0 && preg_match('`Composer version ([^\s]+)`', $lastLine, $matches) === 1) {
+if ($exitcode === 0 && preg_match('`Composer (?:version )?([^\s]+)`', $lastLine, $matches) === 1) {
     define('COMPOSER_VERSION', $matches[1]);
 } else {
     echo 'Could not determine the version of Composer being used.';


### PR DESCRIPTION
## Proposed Changes

Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install Composer 2.2, for PHP 7.2 and up, `v2` will install Composer 2.3.
These extra builds make sure the Composer 2.2 LTS version will continue to be 100% supported for PHP 7.2-8.x.

Refs:
* https://blog.packagist.com/composer-2-3/
* https://github.com/composer/composer/releases/tag/2.3.0

### Test bootstrap: tweak the version determination regex

Apparently, Composer 2.3.0 dropped the word `version` from the `--version` output ;-)

Output on Composer 2.2 and lower:
```
Composer version 2.2.10 2022-03-29 21:55:35
```

Composer 2.3 output:
```
Composer 2.3.0 2022-03-30 11:15:36
```

