### PR TITLE
Update YamLint 

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,7 +1,6 @@
 ---
 name: Linting jobs
 
-# yamllint disable-line rule:truthy
 on:
   - push
   - pull_request

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -1,7 +1,6 @@
 ---
 name: PHP Lint
 
-# yamllint disable-line rule:truthy
 on:
   - push
   - pull_request

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -1,7 +1,6 @@
 ---
 name: Security check
 
-# yamllint disable-line rule:truthy
 on:
   - push
   - pull_request

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -39,6 +39,7 @@ jobs:
         uses: "ramsey/composer-install@v2"
 
       - name: Download security checker
+        # yamllint disable-line rule:line-length
         run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v1.2.0/local-php-security-checker_1.2.0_linux_amd64
 
       - name: Make security checker executable


### PR DESCRIPTION
1. Currently, YamlLint complains about the line-length in `securitycheck.yml` GitHub Worflow.

   ![image](https://user-images.githubusercontent.com/195757/163795141-a3d5aa99-2504-4777-9438-7bf4b6daad78.png)

   This MR resolves that violation by adding a comment telling YamlLint to ~~shut the fuck up~~ kindly ignore that specific line.

   (see https://yamllint.readthedocs.io/en/stable/disable_with_comments.html for documentation details).

2. As using `on:` as a key name is no longer marked as a violation (by the `truthy` rule configuration in the `.yamllint` file), the following diable comment has been removed in all files that had it:

   ```yml
   # yamllint disable-line rule:truthy
   ```