### PR TITLE
GH Actions: fix builds on Windows with PHP 8.2

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -104,6 +104,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: json, zip
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: "composer:${{ matrix.composer }}"
           coverage: none

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -45,6 +45,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          extensions: json, zip
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: "composer:${{ matrix.composer }}"
           coverage: none


### PR DESCRIPTION
## Proposed Changes

Looks like the `zip` extension is not available by default on [Windows with PHP 8.2](https://github.com/shivammathur/setup-php/wiki/Php-extensions-loaded-on-windows-2019#php-82), which is causing those builds to fail as the zip extension is needed in the test bootstrap.

Looking at the `composer.json` file, we previously identified the `json` and `zip` extensions as `dev` requirements, so let's ensure they will always be [installed and enabled in CI](https://github.com/shivammathur/setup-php#heavy_plus_sign-php-extension-support).
