### PR TITLE
Plugin: improve feedback

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -40,7 +40,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         'The value of "%s" (in the composer.json "extra".section) must be an integer larger then %d, %s given.';
 
     const MESSAGE_NOT_INSTALLED      = 'PHPCodeSniffer is not installed';
-    const MESSAGE_NOTHING_TO_INSTALL = 'Nothing to install or update';
+    const MESSAGE_NOTHING_TO_INSTALL = 'No PHPCS standards to install or update';
     const MESSAGE_PLUGIN_UNINSTALLED = 'PHPCodeSniffer Composer Installer is uninstalled';
     const MESSAGE_RUNNING_INSTALLER  = 'Running PHPCodeSniffer Composer Installer';
 


### PR DESCRIPTION
## Proposed Changes

The `Nothing to install or update` message is confusing, as for an end-user, it may not be clear that this message relates to the PHPCS plugin.
The message as-is could be interpreted to relate to Composer itself finding _nothing to install or update_ instead.

I'd like to suggest changing that message to be more directly related to this plugin for clarity.
