### PR TITLE
GH Actions: stop running tests against PHP 5.5/Composer 1.x on Windows (and remove work-arounds)

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -41,6 +41,13 @@ jobs:
           - 'ubuntu-latest'
           - 'windows-latest'
 
+        exclude:
+          # Exclude a particularly problematic build.
+          # @link https://github.com/PHPCSStandards/composer-installer/issues/181
+          - php: '5.5'
+            composer: 'v1'
+            os: 'windows-latest'
+
         include:
           # Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install
           # Composer 2.2, for PHP 7.2 and up, `v2` will install Composer 2.3.

--- a/tests/IntegrationTest/BaseLineTest.php
+++ b/tests/IntegrationTest/BaseLineTest.php
@@ -72,11 +72,10 @@ final class BaseLineTest extends TestCase
         $this->assertComposerValidates(static::$tempGlobalPath);
 
         // Make sure the plugin runs.
-        $expectedStdOut = $this->willPluginOutputShow() ? Plugin::MESSAGE_RUNNING_INSTALLER : null;
         $this->assertExecute(
             'composer global install -v --no-ansi',
             0,    // Expected exit code.
-            $expectedStdOut, // Expected stdout.
+            Plugin::MESSAGE_RUNNING_INSTALLER, // Expected stdout.
             null, // No stderr expectation.
             'Failed to install dependencies.'
         );
@@ -109,6 +108,18 @@ final class BaseLineTest extends TestCase
      */
     public function testBaseLineLocal($phpcsVersion, $expectedStnds)
     {
+        if (
+            $phpcsVersion === PHPCSVersions::MASTER
+            && \CLI_PHP_MINOR === '5.5'
+            && $this->onWindows() === true
+            && substr(\COMPOSER_VERSION, 0, 1) === '1'
+        ) {
+            $this->markTestSkipped(
+                'Composer 1.x on Windows with PHP 5.5 does run the plugin when there are no external standards,'
+                . ' but doesn\'t consistently show this in the logs'
+            );
+        }
+
         $config = $this->composerConfig;
         $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
 
@@ -116,11 +127,10 @@ final class BaseLineTest extends TestCase
         $this->assertComposerValidates(static::$tempLocalPath);
 
         // Make sure the plugin runs.
-        $expectedStdOut = $this->willPluginOutputShow() ? Plugin::MESSAGE_RUNNING_INSTALLER : null;
         $this->assertExecute(
             sprintf('composer install -v --no-ansi --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
             0,    // Expected exit code.
-            $expectedStdOut, // Expected stdout.
+            Plugin::MESSAGE_RUNNING_INSTALLER, // Expected stdout.
             null, // No stderr expectation.
             'Failed to install dependencies.'
         );

--- a/tests/IntegrationTest/InstallUpdateEventsTest.php
+++ b/tests/IntegrationTest/InstallUpdateEventsTest.php
@@ -87,26 +87,11 @@ final class InstallUpdateEventsTest extends TestCase
         $result  = $this->executeCliCommand($command);
 
         $this->assertSame(0, $result['exitcode'], "Exitcode for composer $action did not match 0");
-
-        if ($this->willPluginOutputShow() === true) {
-            $this->assertStringContainsString(
-                Plugin::MESSAGE_RUNNING_INSTALLER,
-                $result['stdout'],
-                "Output from composer $action does not show the plugin as running while it should be."
-            );
-        } else {
-            /*
-             * Composer edge-case where it doesn't show plugin output.
-             * Verify the plugin has run by checking via PHPCS.
-             */
-            $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
-            $this->assertSame(0, $result['exitcode'], 'Exitcode for "--config-show" did not match 0');
-            $this->assertStringContainsString(
-                'installed_paths:',
-                $result['stdout'],
-                'PHPCS has no paths to external standards registered.'
-            );
-        }
+        $this->assertStringContainsString(
+            Plugin::MESSAGE_RUNNING_INSTALLER,
+            $result['stdout'],
+            "Output from composer $action does not show the plugin as running while it should be."
+        );
     }
 
     /**

--- a/tests/IntegrationTest/PlayNiceWithScriptsTest.php
+++ b/tests/IntegrationTest/PlayNiceWithScriptsTest.php
@@ -86,18 +86,15 @@ final class PlayNiceWithScriptsTest extends TestCase
 
         $this->assertSame(0, $result['exitcode'], 'Exitcode for initial composer install did not match 0');
 
-        if ($this->willPluginOutputShow()) {
-            $this->assertStringContainsString(
-                Plugin::MESSAGE_RUNNING_INSTALLER,
-                $result['stdout'],
-                'Output from initial composer install missing expected contents.'
-            );
-        }
+        $this->assertStringContainsString(
+            Plugin::MESSAGE_RUNNING_INSTALLER,
+            $result['stdout'],
+            'Output from initial composer install missing expected contents.'
+        );
 
-        $output = $this->willPluginOutputShow() ? $result['stdout'] : $result['stderr'];
         $this->assertStringContainsString(
             'post-update-cmd successfully run',
-            $output,
+            $result['stdout'],
             'Output from initial composer install missing expected contents.'
         );
 
@@ -125,59 +122,42 @@ final class PlayNiceWithScriptsTest extends TestCase
      */
     public function dataScriptsAreNotBlockedFromRunning()
     {
-        $data           = array();
-        $willOutputShow = self::willPluginOutputShow();
-
-        $data['install:command'] = array(
-            'command'         => 'composer install',
-            'expectedOutputs' => array(
-                'post-install-cmd successfully run',
+        return array(
+            'install:command' => array(
+                'command'         => 'composer install',
+                'expectedOutputs' => array(
+                    'post-install-cmd successfully run',
+                    Plugin::MESSAGE_RUNNING_INSTALLER,
+                ),
+            ),
+            'update:command' => array(
+                'command'         => 'composer update',
+                'expectedOutputs' => array(
+                    'post-update-cmd successfully run',
+                    Plugin::MESSAGE_RUNNING_INSTALLER,
+                ),
+            ),
+            'post-install-cmd:script' => array(
+                'command'         => 'composer run-script post-install-cmd',
+                'expectedOutputs' => array(
+                    Plugin::MESSAGE_RUNNING_INSTALLER,
+                    'post-install-cmd successfully run',
+                ),
+            ),
+            'post-update-cmd:script' => array(
+                'command'         => 'composer run-script post-update-cmd',
+                'expectedOutputs' => array(
+                    Plugin::MESSAGE_RUNNING_INSTALLER,
+                    'post-update-cmd successfully run',
+                ),
+            ),
+            'install-codestandards:script' => array(
+                'command'         => 'composer run-script install-codestandards',
+                'expectedOutputs' => array(
+                    Plugin::MESSAGE_RUNNING_INSTALLER,
+                    'install-codestandards successfully run',
+                ),
             ),
         );
-        if ($willOutputShow) {
-            $data['install:command']['expectedOutputs'][] = Plugin::MESSAGE_RUNNING_INSTALLER;
-        }
-
-        $data['update:command'] = array(
-            'command'         => 'composer update',
-            'expectedOutputs' => array(
-                'post-update-cmd successfully run',
-            ),
-        );
-        if ($willOutputShow) {
-            $data['update:command']['expectedOutputs'][] = Plugin::MESSAGE_RUNNING_INSTALLER;
-        }
-
-        $data['post-install-cmd:script'] = array(
-            'command'         => 'composer run-script post-install-cmd',
-            'expectedOutputs' => array(
-                'post-install-cmd successfully run',
-            ),
-        );
-        if ($willOutputShow) {
-            $data['post-install-cmd:script']['expectedOutputs'][] = Plugin::MESSAGE_RUNNING_INSTALLER;
-        }
-
-        $data['post-update-cmd:script'] = array(
-            'command'         => 'composer run-script post-update-cmd',
-            'expectedOutputs' => array(
-                'post-update-cmd successfully run',
-            ),
-        );
-        if ($willOutputShow) {
-            $data['post-update-cmd:script']['expectedOutputs'][] = Plugin::MESSAGE_RUNNING_INSTALLER;
-        }
-
-        $data['install-codestandards:script'] = array(
-            'command'         => 'composer run-script install-codestandards',
-            'expectedOutputs' => array(
-                'install-codestandards successfully run',
-            ),
-        );
-        if ($willOutputShow) {
-            $data['install-codestandards:script']['expectedOutputs'][] = Plugin::MESSAGE_RUNNING_INSTALLER;
-        }
-
-        return $data;
     }
 }

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -134,12 +134,11 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
         /*
          * 3. Install an external standard.
          */
-        $expectedStdOut = $this->willPluginOutputShow() ? 'PHP CodeSniffer Config installed_paths set to ' : null;
-        $command        = 'composer global require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v';
+        $command = 'composer global require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v';
         $this->assertExecute(
             $command,
             0,    // Expected exit code.
-            $expectedStdOut, // Expectation for stdout.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
             null, // No stderr expectation.
             'Failed to install Dummy subdir standard.'
         );
@@ -246,15 +245,14 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
         /*
          * 3. Install an external standard.
          */
-        $expectedStdOut = $this->willPluginOutputShow() ? 'PHP CodeSniffer Config installed_paths set to ' : null;
-        $command        = sprintf(
+        $command = sprintf(
             'composer require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v --working-dir=%s',
             escapeshellarg(static::$tempLocalPath)
         );
         $this->assertExecute(
             $command,
             0,    // Expected exit code.
-            $expectedStdOut, // Expectation for stdout.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
             null, // No stderr expectation.
             'Failed to install Dummy subdir standard.'
         );

--- a/tests/IntegrationTest/RegisterExternalStandardsTest.php
+++ b/tests/IntegrationTest/RegisterExternalStandardsTest.php
@@ -224,11 +224,10 @@ final class RegisterExternalStandardsTest extends TestCase
         $this->writeComposerJsonFile($config, static::$tempLocalPath);
 
         // Install the dependencies and verify that the plugin has run.
-        $expectedStdOut = $this->willPluginOutputShow() ? 'PHP CodeSniffer Config installed_paths set to ' : null;
         $this->assertExecute(
             sprintf('composer install -v --no-ansi --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
             0,    // Expected exit code.
-            $expectedStdOut, // Expectation for stdout.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
             null, // No stderr expectation.
             'Failed to install dependencies.'
         );
@@ -293,11 +292,10 @@ final class RegisterExternalStandardsTest extends TestCase
         $this->writeComposerJsonFile($config, static::$tempGlobalPath);
 
         // Install the dependencies and verify that the plugin has run.
-        $expectedStdOut = $this->willPluginOutputShow() ? 'PHP CodeSniffer Config installed_paths set to ' : null;
         $this->assertExecute(
             'composer global install -v --no-ansi',
             0,    // Expected exit code.
-            $expectedStdOut, // Expectation for stdout.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
             null, // No stderr expectation.
             'Failed to install dependencies.'
         );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -211,25 +211,6 @@ abstract class TestCase extends PolyfillTestCase
     }
 
     /**
-     * Determine whether output expectations can be set for a typical Composer `install`/`update` run.
-     *
-     * Composer 1.x on Windows with PHP 5.5 DOES run the plugin, but doesn't consistently show this in the logs.
-     * This method can be used to still test output expectations in _most_ cases, without failing the tests
-     * in the rare case they won't show.
-     *
-     * It is recommended to only add a call to this method to a test when it has been proven
-     * to fail without it.
-     *
-     * @return bool
-     */
-    protected static function willPluginOutputShow()
-    {
-        return ((\CLI_PHP_MINOR === '5.5'
-            && self::onWindows() === true
-            && strpos(\COMPOSER_VERSION, '1') === 0) === false);
-    }
-
-    /**
      * Create a composer.json file based on a given configuration.
      *
      * @param array  $config    Composer configuration as an array.


### PR DESCRIPTION
## Proposed Changes

### GH Actions: stop running tests against PHP 5.5/Composer 1.x on Windows

As discussed in #181.

Fixes #181

### Tests: remove the `TestCase::willPluginOutputShow()` helper method and all uses

This method was put in place in PR #153 (commit https://github.com/PHPCSStandards/composer-installer/commit/d4f64b822a76e1aac325f18ac160b9daac01ff49) as a work-around for the problematic PHP 5.5 / Composer v1 on Windows build.

As we won't be running the tests against that particular combination anymore, I propose we remove all these work-arounds from the test suite.

This effectively reverts the following commits (and a little more):
* f0251b838a3c0461056192db13d4dab66bc7d013.
* ccd127f5676213d57ba5fd29fc181b6a2c5972b0.
* d4f64b822a76e1aac325f18ac160b9daac01ff49.

## Related Issues

#181
