### PR TITLE
GH Actions/Securitycheck: update the security checker download

### DIFF
--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -39,10 +39,10 @@ jobs:
 
       - name: Download security checker
         # yamllint disable-line rule:line-length
-        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.4/local-php-security-checker_2.0.4_linux_amd64
+        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.5/local-php-security-checker_2.0.5_linux_amd64
 
       - name: Make security checker executable
-        run: chmod +x ./local-php-security-checker_2.0.4_linux_amd64
+        run: chmod +x ./local-php-security-checker_2.0.5_linux_amd64
 
       - name: Check against insecure dependencies
-        run: ./local-php-security-checker_2.0.4_linux_amd64 --path=composer.lock
+        run: ./local-php-security-checker_2.0.5_linux_amd64 --path=composer.lock


### PR DESCRIPTION
## Proposed Changes

The security checker binary has had a new release. I've reviewed the diff, changes look fine.

Refs:
* https://github.com/fabpot/local-php-security-checker/releases/tag/v2.0.5
* https://github.com/fabpot/local-php-security-checker/compare/v2.0.4...v2.0.5
