### PR TITLE
Rename namespace prefix from `Dealerdirect`  to `PHPCSStandards`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ section of the `composer.json`:
 {
     "scripts": {
         "install-codestandards": [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+            "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ]
     }
 }
@@ -124,7 +124,7 @@ referenced from other script configurations, as follows:
 {
     "scripts": {
         "install-codestandards": [
-            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+            "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
         ],
         "post-install-cmd": [
             "@install-codestandards"

--- a/composer.json
+++ b/composer.json
@@ -43,20 +43,20 @@
   "prefer-stable": true,
   "autoload": {
     "psr-4": {
-      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+      "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Tests\\": "tests/"
+      "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Tests\\": "tests/"
     }
   },
   "extra": {
-    "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+    "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
   },
   "scripts": {
     "install-codestandards": [
-      "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
+      "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
     ],
     "lint": [
       "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
     </testsuites>
 
     <listeners>
-        <listener class="Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\DebugTestListener" />
+        <listener class="PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\DebugTestListener" />
     </listeners>
 
     <filter>

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;

--- a/tests/CreateComposerZipArtifacts.php
+++ b/tests/CreateComposerZipArtifacts.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
 use DirectoryIterator;
 use RecursiveCallbackFilterIterator;

--- a/tests/DebugTestListener.php
+++ b/tests/DebugTestListener.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
 use PHPUnit\Framework\TestListener;
 use Yoast\PHPUnitPolyfills\TestListeners\TestListenerDefaultImplementation;

--- a/tests/IntegrationTest/BaseLineTest.php
+++ b/tests/IntegrationTest/BaseLineTest.php
@@ -8,11 +8,11 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test baseline.

--- a/tests/IntegrationTest/InstallUpdateEventsTest.php
+++ b/tests/IntegrationTest/InstallUpdateEventsTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin is hooked into the right events and doesn't get triggered when those events are blocked.
@@ -42,7 +42,7 @@ final class InstallUpdateEventsTest extends TestCase
         ),
         'scripts'     => array(
             'custom-runner'    => array(
-                'Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
+                'PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
             ),
             'post-install-cmd' => array(
                 'echo "post-install-cmd successfully run"',

--- a/tests/IntegrationTest/InstalledPathsOrderTest.php
+++ b/tests/IntegrationTest/InstalledPathsOrderTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin always registers the installed_paths in the same order.

--- a/tests/IntegrationTest/InvalidPackagesTest.php
+++ b/tests/IntegrationTest/InvalidPackagesTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin does not act on packages which are not valid PHPCS standards.

--- a/tests/IntegrationTest/NonInstallUpdateEventsTest.php
+++ b/tests/IntegrationTest/NonInstallUpdateEventsTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin doesn't get triggered on events it isn't hooked into.

--- a/tests/IntegrationTest/PlayNiceWithScriptsTest.php
+++ b/tests/IntegrationTest/PlayNiceWithScriptsTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin does not block other post install/update scripts from running.
@@ -39,7 +39,7 @@ final class PlayNiceWithScriptsTest extends TestCase
                 'echo "post-update-cmd successfully run"',
             ),
             'install-codestandards' => array(
-                'Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
+                'PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
                 'echo "install-codestandards successfully run"',
             ),
         ),

--- a/tests/IntegrationTest/PreexistingPHPCSConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSConfigTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test correctly handling a pre-existing PHPCS configuration file.

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 use RuntimeException;
 
 /**

--- a/tests/IntegrationTest/RegisterExternalStandardsTest.php
+++ b/tests/IntegrationTest/RegisterExternalStandardsTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\PHPCSVersions;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test registering external standards.

--- a/tests/IntegrationTest/RemovePluginTest.php
+++ b/tests/IntegrationTest/RemovePluginTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test plugin does not throw errors when the plugin is still in memory, but PHPCS and the plugin are uninstalled.

--- a/tests/IntegrationTest/RootPackageHandlingTest.php
+++ b/tests/IntegrationTest/RootPackageHandlingTest.php
@@ -8,10 +8,10 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\IntegrationTest;
 
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
-use Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
+use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
 
 /**
  * Test that the plugin correctly registers standards found in the root package if it is an external standard,

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
 /**
  * Helper class to retrieve PHPCS versions suitable for the current PHP version.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -243,7 +243,7 @@ abstract class TestCase extends PolyfillTestCase
         // Inject ability to run the plugin via a script.
         if (isset($config['scripts']['install-codestandards']) === false) {
             $config['scripts']['install-codestandards'] = array(
-                'Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
+                'PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run',
             );
         }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,7 +8,7 @@
  * @license MIT
  */
 
-namespace Dealerdirect\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
+namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
 /*
  * Make sure the tests always start with a clean slate.


### PR DESCRIPTION

## Proposed Changes

As discussed in issue #188.

**Important**: this needs a "breaking change" changelog entry as the command to run the plugin directly (either manually or via a script) has changed. See the README updates for the change which needs to be highlighted in the changelog.


## Related Issues

Fixes #188
