### PR TITLE
GH Actions: various tweaks / PHP 8.2 not allowed to fail

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -34,6 +34,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
         composer:
           - 'v1'
           - 'v2'
@@ -70,6 +71,9 @@ jobs:
           - php: '8.2'
             composer: '2.2'
             os: 'ubuntu-latest'
+          - php: '8.3'
+            composer: '2.2'
+            os: 'ubuntu-latest'
 
           - php: '7.2'
             composer: '2.2'
@@ -89,6 +93,9 @@ jobs:
           - php: '8.2'
             composer: '2.2'
             os: 'windows-latest'
+          - php: '8.3'
+            composer: '2.2'
+            os: 'windows-latest'
 
           # Also test against the dev version of Composer for early warning about upcoming changes.
           - php: 'latest'
@@ -101,7 +108,7 @@ jobs:
 
     name: "Integration test"
 
-    continue-on-error: ${{ matrix.php == '8.2' || matrix.composer == 'snapshot' }}
+    continue-on-error: ${{ matrix.php == '8.3' || matrix.composer == 'snapshot' }}
 
     steps:
       - name: Checkout code
@@ -123,7 +130,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        if: ${{ matrix.php != '8.2' }}
+        if: ${{ matrix.php != '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: '--optimize-autoloader'
@@ -131,7 +138,7 @@ jobs:
           custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php == '8.2' }}
+        if: ${{ matrix.php == '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: '--ignore-platform-reqs --optimize-autoloader'

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -134,15 +134,15 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: '--optimize-autoloader'
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies
         if: ${{ matrix.php == '8.3' }}
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: '--ignore-platform-reqs --optimize-autoloader'
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run integration tests
         run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
         run: composer lint -- --checkstyle | cs2pr

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -60,8 +60,8 @@ jobs:
         uses: "ramsey/composer-install@v2"
         with:
           composer-options: '--optimize-autoloader'
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run integration tests
         run: vendor/bin/phpunit --no-coverage

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
         with:
-          # Bust the cache at least once a month - output format: YYYY-MM-DD.
-          custom-cache-suffix: $(date -u -d "-0 month -$(($(date +%d)-1)) days" "+%F")
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Download security checker
         # yamllint disable-line rule:line-length

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -42,10 +42,10 @@ jobs:
 
       - name: Download security checker
         # yamllint disable-line rule:line-length
-        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.5/local-php-security-checker_2.0.5_linux_amd64
+        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.6/local-php-security-checker_2.0.6_linux_amd64
 
       - name: Make security checker executable
-        run: chmod +x ./local-php-security-checker_2.0.5_linux_amd64
+        run: chmod +x ./local-php-security-checker_2.0.6_linux_amd64
 
       - name: Check against insecure dependencies
-        run: ./local-php-security-checker_2.0.5_linux_amd64 --path=composer.lock
+        run: ./local-php-security-checker_2.0.6_linux_amd64 --path=composer.lock

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -84,6 +84,8 @@ final class PHPCSVersions
         '3.6.0' => '3.6.0',
         '3.6.1' => '3.6.1',
         '3.6.2' => '3.6.2',
+        '3.7.0' => '3.7.0',
+        '3.7.1' => '3.7.1',
     );
 
     /**
@@ -342,6 +344,16 @@ final class PHPCSVersions
                 break;
 
             case '8.2':
+                $versions = array_filter(
+                    self::$allPhpcsVersions,
+                    function ($version) {
+                        // PHPCS 3.6.1 is the first PHPCS version with runtime support for PHP 8.2.
+                        return version_compare($version, '3.6.1', '>=');
+                    }
+                );
+                break;
+
+            case '8.3':
                 /*
                  * At this point in time, it is unclear as of which PHPCS version PHP 8.2 will be supported.
                  * In other words: tests should only use dev-master/4.x when on PHP 8.2 for the time being.


### PR DESCRIPTION
## Proposed Changes

### GH Actions/Securitycheck: update the security checker download

The security checker binary has had a new release, so let's take advantage of it.

Refs:
* https://github.com/fabpot/local-php-security-checker/releases
* https://github.com/fabpot/local-php-security-checker/blob/v2.0.6/CHANGELOG.md

### GH Actions: update PHP versions in workflows

PHP 8.2 has been released today 🎉 and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.

### GH Actions: minor simplification

... of the bash `date` command in the earlier pulled cache busting.


