### PR TITLE
GH Actions: selectively use `fail-fast` with setup-php

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -122,6 +122,7 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: "composer:${{ matrix.composer }}"
           coverage: none
+          fail-fast: true
 
       - name: "Conditionally disable tls (Composer 1.x/Windows/PHP 5.4)"
         if: ${{ matrix.os == 'windows-latest' && matrix.composer == 'v1' && matrix.php == '5.4' }}

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -49,6 +49,7 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           tools: "composer:${{ matrix.composer }}"
           coverage: none
+          fail-fast: true
 
       - name: "Conditionally disable tls (Composer 1.x/Windows/PHP 5.4)"
         if: ${{ matrix.os == 'windows-latest' && matrix.composer == 'v1' && matrix.php == '5.4' }}


### PR DESCRIPTION
## Proposed Changes

I've seen some recent build failures (elsewhere) due to the `setup-php` action running into a rate limit and not downloading the required version of Composer. In the case of this package, that would make the test runs worthless.

The `setup-php` action runner defaults to _showing_ these type errors in the logs, but not stopping the workflow run.

So, specifically for those jobs where the Composer version is important, I'm adding the `fail-fast` option to `setup-php` to fail the build if the action runner ran into any errors.

Ref: https://github.com/shivammathur/setup-php#fail-fast-optional


