### PR TITLE
.gitattributes: sync with current repo state

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,18 @@
 # Ignore files for distribution archives.
 
-.editorconfig             export-ignore
-.gitattributes            export-ignore
-.gitignore                export-ignore
-.github                   export-ignore
+.editorconfig               export-ignore
+.gitattributes              export-ignore
+.github_changelog_generator export-ignore
+.gitignore                  export-ignore
+.remarkrc                   export-ignore
+.yamllint                   export-ignore
 
-CONTRIBUTING.md           export-ignore
-phpcs.xml.dist            export-ignore
-phpunit.xml.dist          export-ignore
+CODE_OF_CONDUCT.md          export-ignore
+CONTRIBUTING.md             export-ignore
+phpcs.xml.dist              export-ignore
+phpunit.xml.dist            export-ignore
 
 # Ignore directories for distribution archives.
-/tests/                   export-ignore
+/.github/                   export-ignore
+/bin/                       export-ignore
+/tests/                     export-ignore


### PR DESCRIPTION
## Proposed Changes

A number of dev-related files/directories were not listed in the `.gitattributes` file, while these don't need to be included in the distribution archives.

Fixed now.
