### PR TITLE
Add COMPOSER_AUTH env variable to workflows

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -10,6 +10,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+env:
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -7,6 +7,9 @@ on:
   # Allow manually triggering the workflow.
   - workflow_dispatch
 
+env:
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -9,6 +9,9 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+env:
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -7,6 +7,9 @@ on:
   # Allow manually triggering the workflow.
   - workflow_dispatch
 
+env:
+  COMPOSER_AUTH: '{"github-oauth": {"github.com": "${{ secrets.GITHUB_TOKEN }}"}}'
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.


### PR DESCRIPTION
## Proposed Changes

Because of the amount of GitHub API calls composer does, the CI runs into a rate limit. This causes jobs to fail or be aborted. Adding the GITHUB_TOKEN as auth method _should_ avoid these rate limits.

## Related Issues

- #196