### PR TITLE
Rename references to `master` branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -49,5 +49,5 @@ Output of `vendor/bin/phpcs --config-show`:
 (Please paste the output you get here)
 ```
 
-## Tested against `master` branch?
-- [ ] I have verified the issue still exists in the `master` branch.
+## Tested against `main` branch?
+- [ ] I have verified the issue still exists in the `main` branch.

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -2,10 +2,10 @@
 name: Integration Test
 
 on:
-  # Run on pushes to `master` and on all pull requests.
+  # Run on pushes to `main` and on all pull requests.
   push:
     branches:
-      - master
+      - main
   pull_request:
   # Allow manually triggering the workflow.
   workflow_dispatch:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -5,7 +5,7 @@ on:
   # Run on pushes to feature branches.
   push:
     branches-ignore:
-      - master
+      - main
   # Allow manually triggering the workflow.
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ before making a change.
 Please note we have [a code of conduct][], please follow it in all your interactions
 with the project.
 
-[a code of conduct]: https://github.com/PHPCSStandards/composer-installer/blob/master/CODE_OF_CONDUCT.md
+[a code of conduct]: https://github.com/PHPCSStandards/composer-installer/blob/main/CODE_OF_CONDUCT.md
 
 ## Issues and feature requests
 
@@ -131,7 +131,7 @@ A changelog can be generated using the [`github-changelog-generator`][github-cha
 
 Our release versions follow [Semantic Versioning][semver].
 
-New releases (and any related tags) are always created from the `master` branch.
+New releases (and any related tags) are always created from the `main` branch.
 
 To create a new release:
 


### PR DESCRIPTION
This PR is to be merged in conjunction with the branch rename to `main` as discussed in 160

Fixes 160, supersedes https://github.com/PHPCSStandards/composer-installer/pull/199