### PR TITLE
Change project stage in README to "production read".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP_CodeSniffer Standards Composer Installer Plugin
 
-![Project Stage][project-stage-shield]
+[![Project stage: Production Ready][project-stage-shield]][project-stage-page]
 ![Last Commit][last-updated-shield]
 ![Awesome][awesome-shield]
 [![License][license-shield]](LICENSE.md)
@@ -274,7 +274,8 @@ THE SOFTWARE.
 [packagist-version]: https://packagist.org/packages/dealerdirect/phpcodesniffer-composer-installer
 [packagist]: https://packagist.org/packages/dealerdirect/phpcodesniffer-composer-installer
 [`phpcodesniffer-standard` packages]: https://packagist.org/explore/?type=phpcodesniffer-standard
-[project-stage-shield]: https://img.shields.io/badge/Project%20Stage-Development-yellowgreen.svg
+[project-stage-page]: https://blog.pother.ca/project-stages/
+[project-stage-shield]: https://img.shields.io/badge/Project%20Stage-Production%20Ready-brightgreen.svg
 [scrutinizer-shield]: https://img.shields.io/scrutinizer/g/dealerdirect/phpcodesniffer-composer-installer.svg
 [scrutinizer]: https://scrutinizer-ci.com/g/dealerdirect/phpcodesniffer-composer-installer/
 [ghactionstest-shield]: https://github.com/PHPCSStandards/composer-installer/actions/workflows/integrationtest.yml/badge.svg


### PR DESCRIPTION
This MR changes the badge for "Project Stage" to "Production Ready" (as the project has reached a v1).
A link to the page which explains the rational behind the badge is also added.

**Question to be aswered**: Should we _update_ the badge or does it make more sense to _remove_ it?
Orignally it was added to make clear (in the "swag" section) that the project was not yet production ready, as not everyone seems to understand what `v0` versions seem to mean. However, as the default assumption seems to be that any project _is_ production ready (unless otherwise stated) is the badge still needed?