### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+# Dependabot configuration.
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5 # Set to 0 to (temporarily) disable.
+    versioning-strategy: widen
+    allow:
+      # Only allow updates to the dev dependencies as non-dev dependency
+      # updates will generally need code changes in this package.
+      - dependency-type: "development"
+    ignore:
+      # A new PHPUnit major will generally require a managed update,
+      # so do not allow automated PRs.
+      - dependency-name: "yoast/phpunit-polyfills"
+        update-types: ["version-update:semver-major"]
+    commit-message:
+      prefix: "Composer:"
+      include: "scope"
+    labels:
+      - "builds / deploys / releases"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "GH Actions:"
+    labels:
+      - "builds / deploys / releases"


### PR DESCRIPTION
## Proposed Changes

This automatically enables Dependabot to:
* Submit pull requests for security updates and version updates for Composer dependencies.
* Submit pull requests for security updates and version updates for GH Action runner dependencies.

For Composer dependencies, a preference is given to _widen_ the version restrictions instead of updating them to a new minimum. This is a deliberate choice as this package is a library, not an application.

The configuration has been set up to:
* Run once a week.
* Submit a maximum of 5 pull requests at a time. If additional pull requests are needed, these will subsequently be submitted the next time Dependabot runs after one or more of the open pull requests have been merged.
* The commit messages for PRs submitted by Dependabot will be prefixed according the unofficial conventions used in this repo up to now.
* The PRs will automatically be labelled with an appropriate label as already in use in this repo.

Additionally, for Composer updates, I've applied the following restrictions:
* Only allow updates for "dev" dependencies, as non-dev dependencies (PHPCS, Composer Installers) will need a code review and likely warrant code changes.
* Ignore major releases of the PHPUnit Polyfills package (= new PHPUnit major) as those generally require a managed update of the test suite.

Refs:
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
* https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy

