### PR TITLE
Allow use within PHP_CodeSniffer itself

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -538,6 +538,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getPHPCodeSnifferPackage($versionConstraint = null)
     {
+        $rootPackage = $this->composer->getPackage();
+        if ($rootPackage->getName() === self::PACKAGE_NAME) {
+            return $rootPackage;
+        }
+
         $packages = $this
             ->composer
             ->getRepositoryManager()
@@ -554,7 +559,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getPHPCodeSnifferInstallPath()
     {
-        return $this->composer->getInstallationManager()->getInstallPath($this->getPHPCodeSnifferPackage());
+        $package = $this->getPHPCodeSnifferPackage();
+        if ($package instanceof \Composer\Package\RootPackageInterface) {
+            return realpath(dirname(\Composer\Factory::getComposerFile()));
+        }
+
+        return $this->composer->getInstallationManager()->getInstallPath($package);
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

While looking into changing the coding standard used for PHP_CodeSniffer itself, I noticed that this plug-in doesn't currently work in that scenario. This pull request allows this plug-in to be used within the PHP_CodeSniffer repository.

## Related Issues

Related to https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/122#pullrequestreview-1762881173