### PR TITLE
Composer: avoid writing a lock file

### DIFF
--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -32,6 +32,9 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
+      - name: Enable creation of `composer.lock` file
+        run: composer config --unset lock
+
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
       "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Tests\\": "tests/"
     }
   },
+  "config": {
+    "lock": false
+  },
   "extra": {
     "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
   },


### PR DESCRIPTION
## Proposed Changes

When working with this repository as a developer, we should be using the latest compatible packages. By writing a lock file for Composer, we may get into a state where we are "stuck" on an older version of a dependency. This change avoids such a situation by telling Composer to not write out a lock file in the project.