### PR TITLE
GH Actions: stop testing with PHP 8.4 against Composer < current

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -54,11 +54,19 @@ jobs:
           # @link https://github.com/PHPCSStandards/composer-installer/pull/213
           - php: '5.4'
             os: 'windows-latest'
+          # Composer 1.x is no longer supported and while Composer 2.2 is an LTS version, the LTS
+          # is only for critical bugs and security issues, not for supporting new PHP versions.
+          # In practice, this means that Composer 1.x and 2.2 are not compatible with PHP 8.4 and later.
+          # @link https://github.com/composer/composer/issues/10340
+          - php: '8.4'
+            composer: 'v1'
 
         include:
           # Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install
           # Composer 2.2, for PHP 7.2 and up, `v2` will install Composer 2.3.
-          # These builds make sure the Composer 2.2 LTS version is 100% supported for PHP 7.2-8.x.
+          # These builds make sure the Composer 2.2 LTS version is 100% supported for PHP 7.2-8.3.
+          # Note: Composer 2.2 is not compatible with PHP 8.4 and it is unlikely that it will be
+          # made compatible with PHP 8.4.
           - php: '7.2'
             composer: '2.2'
             os: 'ubuntu-latest'
@@ -78,9 +86,6 @@ jobs:
             composer: '2.2'
             os: 'ubuntu-latest'
           - php: '8.3'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '8.4'
             composer: '2.2'
             os: 'ubuntu-latest'
 
@@ -103,9 +108,6 @@ jobs:
             composer: '2.2'
             os: 'windows-latest'
           - php: '8.3'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '8.4'
             composer: '2.2'
             os: 'windows-latest'
 


### PR DESCRIPTION
## Proposed Changes

Composer 1.x is no longer supported and while Composer 2.2 is an LTS version, the LTS is only for critical bugs and security issues, not necessarily for supporting new PHP versions.

The LTS support was also officially only in effect until end of 2023 (and I have not seen any announcement of an extension).

In practice, this means the following:
* Composer 1.x and Composer 2.2. were previously made compatible with PHP 8.2 and 8.3 (released since the announcement).
* However, it is unlikely that Composer 1.x and Composer 2.2 will be made compatible with PHP 8.4 and builds against those combinations are already failing.

With the above in mind, I propose to stop running the tests against Composer 1.x/2.2 - PHP 8.4 combinations as they can only fail and those failures are not related to the plugin and outside our sphere of influence to fix.

This commit updates the `integrationtest` workflow to put the above into effect.

The `quicktest` workflow is currently not (yet) affected, but will be once PHP "latest" becomes PHP 8.4 towards the end of the year. At that time, a tweak will need to be made to the quicktest workflow as well.

Ref:
* https://github.com/composer/composer/issues/10340