### PR TITLE
GH Actions: show deprecations when linting & lint against next PHP version

### DIFF
--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -19,7 +19,9 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.6', '7.2', 'latest']
+        php: ['5.4', '5.6', '7.2', 'latest', 'nightly']
+
+    continue-on-error: ${{ matrix.php == 'nightly' }}
 
     name: "PHP Lint: PHP ${{ matrix.php }}"
 

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
       "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run"
     ],
     "lint": [
-      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude .git"
+      "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --show-deprecated --exclude vendor --exclude .git"
     ],
     "test": [
       "@php ./vendor/phpunit/phpunit/phpunit --no-coverage"


### PR DESCRIPTION
## Proposed Changes

### GH Actions: show deprecations when linting

While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.

### GH Actions: also lint against _next_ PHP version

The PHP lint job currently checks all PHP files for parse/compile errors against a limited set of PHP versions, including the high/low versions.

It did not run the linter against the _next_ (upcoming) PHP version yet.

This has now been added with the `'nightly'` alias, which means that the version will automatically roll through to the next PHP version when a new PHP branchs gets cut, without us needing to manually maintain this.

Also note that the build against `nightly` is allowed to fail.
