### PR TITLE
Ignore development-only packages in security check

### DIFF
--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -35,9 +35,6 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
 
-      - name: Enable creation of `composer.lock` file
-        run: composer config --unset lock
-
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
@@ -56,4 +53,4 @@ jobs:
         run: chmod +x ./local-php-security-checker_2.0.6_linux_amd64
 
       - name: Check against insecure dependencies
-        run: ./local-php-security-checker_2.0.6_linux_amd64 --path=composer.lock
+        run: ./local-php-security-checker_2.0.6_linux_amd64 --path=vendor/composer/installed.json

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -45,6 +45,8 @@ jobs:
         with:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
+          # Ignore development-only packages in security check
+          composer-options: "--no-dev"
 
       - name: Download security checker
         # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Proposed Changes

Only perform security check on actual dependencies / ignore development-only dependencies for this check.

## Related Issues

https://github.com/PHPCSStandards/composer-installer/pull/228#issuecomment-2492542642
