### PR TITLE
Drop support for Composer v1.x

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -41,31 +41,17 @@ jobs:
           - '8.4'
           - '8.5'
         composer:
-          - 'v1'
           - 'v2'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
 
         exclude:
-          # Exclude a particularly problematic build.
-          # @link https://github.com/PHPCSStandards/composer-installer/issues/181
-          - php: '5.5'
-            composer: 'v1'
-            os: 'windows-latest'
           # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
           # Considering PHP 5.4 is ancient, I deem it acceptable to exclude the Windows PHP 5.4 builds.
           # @link https://github.com/PHPCSStandards/composer-installer/pull/213
           - php: '5.4'
             os: 'windows-latest'
-          # Composer 1.x is no longer supported and while Composer 2.2 is an LTS version, the LTS
-          # is only for critical bugs and security issues, not for supporting new PHP versions.
-          # In practice, this means that Composer 1.x and 2.2 are not compatible with PHP 8.4 and later.
-          # @link https://github.com/composer/composer/issues/10340
-          - php: '8.4'
-            composer: 'v1'
-          - php: '8.5'
-            composer: 'v1'
 
         include:
           # Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -32,14 +32,15 @@ jobs:
           - '7.2'
           - 'latest'
         composer:
-          - 'v1'
+          # Note: for PHP 5.4 - 7.1, "v2" will install Composer 2.2.
+          # For PHP 7.2+, it will install Composer "latest".
           - 'v2'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
 
         # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
-        # Exclude the Windows PHP 5.4 builds and replace them with PHP 5.5/5.6 for the same.
+        # Exclude the Windows PHP 5.4 builds and replace them with PHP 5.5 for the same.
         # @link https://github.com/PHPCSStandards/composer-installer/issues/181
         # @link https://github.com/PHPCSStandards/composer-installer/pull/213
         exclude:
@@ -47,10 +48,6 @@ jobs:
             os: 'windows-latest'
         include:
           - php: '5.5'
-            composer: 'v2'
-            os: 'windows-latest'
-          - php: '5.6'
-            composer: 'v1'
             os: 'windows-latest'
 
     name: "Quick test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,12 @@ Even better: You could submit a pull request with a fix / new feature!
 ### (Code) Quality checks
 
 Every merge-request triggers a build process which runs various checks to help
-maintain a quality standard. All JSON, Markdown, PHP, and Yaml files are 
+maintain a quality standard. All JSON, Markdown, PHP, and Yaml files are
 expected to adhere to these quality standards.
 
 These tools fall into two categories: PHP and non-PHP.
 
-### PHP 
+### PHP
 
 The PHP specific tools used by this build are:
 
@@ -99,7 +99,7 @@ In case the test setup has trouble locating your `composer.phar` file:
     </php>
     ```
     **Note**: this setting also allows for locally testing with different versions of Composer.
-    You could, for instance, have multiple Composer Phar files locally, `composer1.phar`, `composer2.1.phar`, `composer2.2.phar`.
+    You could, for instance, have multiple Composer Phar files locally, `composer.phar`, `composer2.2.phar`, `composer2.6.phar`.
     By changing the path in the value of this `env` setting, you can switch which version will be used in the tests.
 
 ### Non-PHP
@@ -112,7 +112,7 @@ The non-PHP specific tools used by this build are:
 
 These tools are also run as [GitHub actions][].
 All the checks can be run locally using [`act`][].
-Alternatively they can be run using `docker run`, as all checks use Docker 
+Alternatively they can be run using `docker run`, as all checks use Docker
 images provided by [Pipeline-Component][].
 
 Finally, they could be run locally using NodeJS, Ruby, PHP, or whatever the tool

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Installation can be done with [Composer][composer], by requiring this package as
 composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^1.0"
 ```
 
-When using Composer 2.2 or higher, Composer will [ask for your permission](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) to allow this plugin to execute code. For this plugin to be functional, permission needs to be granted.
+Since Composer 2.2, Composer will [ask for your permission](https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution) to allow this plugin to execute code. For this plugin to be functional, permission needs to be granted.
 
 When permission has been granted, the following snippet will automatically be added to your `composer.json` file by Composer:
 ```json
@@ -36,7 +36,7 @@ When permission has been granted, the following snippet will automatically be ad
 }
 ```
 
-When using Composer < 2.2, you can add the permission flag ahead of the upgrade to Composer 2.2, by running:
+You can safely add the permission flag (to avoid Composer needing to ask), by running:
 ```bash
 composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 ```
@@ -48,7 +48,7 @@ That's it.
 This plugin is compatible with:
 
 - PHP **5.4+**, **7.x**, and **8.x** (Support for PHP v8 is available since [`v0.7.0`][v0.7])
-- [Composer][composer] **1.x** and **2.x** (Support for Composer v2 is available since [`v0.7.0`][v0.7])
+- [Composer][composer] **2.2+** (Support for Composer v2 is available since [`v0.7.0`][v0.7]; support for Composer < 2.2 was dropped in [`v1.1.0`][v1.1])
 - [PHP_CodeSniffer][codesniffer] **2.x** and **3.x** (Support for PHP_CodeSniffer v3 is available since [`v0.4.0`][v0.4])
 
 ### How it works
@@ -283,3 +283,4 @@ THE SOFTWARE.
 [using-composer-plugins]: https://getcomposer.org/doc/articles/plugins.md#using-plugins
 [v0.4]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v0.4.0
 [v0.7]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v0.7.0
+[v1.1]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.1.0

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
   },
   "require": {
     "php": ">=5.4",
-    "composer-plugin-api": "^1.0 || ^2.0",
+    "composer-plugin-api": "^2.2",
     "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
   },
   "require-dev": {
     "ext-json": "*",
     "ext-zip": "*",
-    "composer/composer": "*",
+    "composer/composer": "^2.2",
     "phpcompatibility/php-compatibility": "^9.0",
     "php-parallel-lint/php-parallel-lint": "^1.3.1",
     "yoast/phpunit-polyfills": "^1.0"

--- a/tests/IntegrationTest/BaseLineTest.php
+++ b/tests/IntegrationTest/BaseLineTest.php
@@ -108,18 +108,6 @@ final class BaseLineTest extends TestCase
      */
     public function testBaseLineLocal($phpcsVersion, $expectedStnds)
     {
-        if (
-            $phpcsVersion === PHPCSVersions::MASTER
-            && \CLI_PHP_MINOR === '5.5'
-            && $this->onWindows() === true
-            && substr(\COMPOSER_VERSION, 0, 1) === '1'
-        ) {
-            $this->markTestSkipped(
-                'Composer 1.x on Windows with PHP 5.5 does run the plugin when there are no external standards,'
-                . ' but doesn\'t consistently show this in the logs'
-            );
-        }
-
         $config = $this->composerConfig;
         $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
 

--- a/tests/IntegrationTest/InstallUpdateEventsTest.php
+++ b/tests/IntegrationTest/InstallUpdateEventsTest.php
@@ -177,7 +177,7 @@ final class InstallUpdateEventsTest extends TestCase
     }
 
     /**
-     * Test that the plugin runs (or doesn't run) when Composer is invoked with the --no-scripts argument.
+     * Test that the plugin runs when Composer is invoked with the --no-scripts argument.
      *
      * Note: the behaviour of Composer changed in 2.1.2. Prior to that, `--no-scripts` would
      * also stop plugins from running. As of Composer 2.1.2, `--no-scripts` and `--no-plugins`
@@ -198,20 +198,11 @@ final class InstallUpdateEventsTest extends TestCase
 
         $this->assertSame(0, $result['exitcode'], 'Exitcode for composer install did not match 0');
 
-        if (version_compare(\COMPOSER_VERSION, '2.1.2', '>=') === true) {
-            $this->assertStringContainsString(
-                Plugin::MESSAGE_RUNNING_INSTALLER,
-                $result['stdout'],
-                'Output from running Composer install missing expected contents.'
-            );
-        } else {
-            // Composer 1.x.
-            $this->assertStringNotContainsString(
-                Plugin::MESSAGE_RUNNING_INSTALLER,
-                $result['stdout'],
-                'Output from running Composer install contains unexpected contents.'
-            );
-        }
+        $this->assertStringContainsString(
+            Plugin::MESSAGE_RUNNING_INSTALLER,
+            $result['stdout'],
+            'Output from running Composer install missing expected contents.'
+        );
     }
 
     /**

--- a/tests/IntegrationTest/RemovePluginTest.php
+++ b/tests/IntegrationTest/RemovePluginTest.php
@@ -57,24 +57,6 @@ final class RemovePluginTest extends TestCase
     }
 
     /**
-     * Helper method to get the stdout expectation for when the plugin is uninstalled.
-     *
-     * As of Composer 2.0.0, plugins which have been uninstalled will not run anymore
-     * after the uninstall (which is good).
-     * It is unclear which particular change this can be attributed to.
-     *
-     * @return string
-     */
-    private function getUninstallStdOutExpectation()
-    {
-        if (strpos(\COMPOSER_VERSION, '1') === 0) {
-            return Plugin::MESSAGE_PLUGIN_UNINSTALLED;
-        }
-
-        return '';
-    }
-
-    /**
      * Test the plugin doesn't exit with a non-0 exit code and doesn't throw errors when PHPCS and the plugin
      * were installed via --dev and a no-dev install is run, which removes the plugin and PHPCS.
      *
@@ -101,7 +83,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             'composer global install --no-dev -v --no-ansi',
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall by switching to no-dev did not meet expectations.'
         );
@@ -133,7 +115,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             sprintf('composer install --no-dev -v --no-ansi --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall by switching to no-dev did not meet expectations.'
         );
@@ -166,7 +148,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             'composer global remove --dev phpcs-composer-installer/multistandard -v --no-ansi',
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall of dev dependency did not meet expectations.'
         );
@@ -203,7 +185,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             $command,
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall of dev dependency did not meet expectations.'
         );
@@ -236,7 +218,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             'composer global remove phpcs-composer-installer/multistandard -v --no-ansi',
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall of no-dev dependency did not meet expectations.'
         );
@@ -273,7 +255,7 @@ final class RemovePluginTest extends TestCase
         $this->assertExecute(
             $command,
             0,    // Expected exit code.
-            $this->getUninstallStdOutExpectation(), // Expected stdout.
+            null, // No stdout expectation.
             null, // No stderr expectation.
             'Uninstall of no-dev dependency did not meet expectations.'
         );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -252,14 +252,6 @@ abstract class TestCase extends PolyfillTestCase
             $config['config']['allow-plugins']['dealerdirect/phpcodesniffer-composer-installer'] = true;
         }
 
-        /*
-         * Disable TLS when on Windows with Composer 1.x and PHP 5.4.
-         * @link https://github.com/composer/composer/issues/10495
-         */
-        if (static::onWindows() === true && \CLI_PHP_MINOR === '5.4' && strpos(\COMPOSER_VERSION, '1') === 0) {
-            $config['config']['disable-tls'] = true;
-        }
-
         $encoded = json_encode($config, \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
         if (json_last_error() !== \JSON_ERROR_NONE || $encoded === false) {
             throw new RuntimeException('Provided configuration can not be encoded to valid JSON');


### PR DESCRIPTION
## Proposed Changes

Composer themselves will no longer support version 1.x beyond 1st August 2025. Composer version 2.0 was released in October 2020, which is more than four years ago. Anyone wanting to use this plug-in with Composer v1.x can use any existing version.

https://blog.packagist.com/composer-2-0-is-now-available/
https://blog.packagist.com/deprecating-composer-1-support/
https://blog.packagist.com/shutting-down-packagist-org-support-for-composer-1-x/

## Related Issues

- This is step one of three for https://github.com/PHPCSStandards/composer-installer/issues/221
