### PR TITLE
Tests: allow for tests to use root package

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -71,7 +71,7 @@ if (\defined('__PHPUNIT_PHAR__')) {
 define('ZIP_ARTIFACT_DIR', __DIR__ . '/artifact/');
 
 if (extension_loaded('zip') === true) {
-    define('PLUGIN_ARTIFACT_VERSION', '1.0.0');
+    define('PLUGIN_ARTIFACT_VERSION', '1.99.99');
 
     $zipCreator = new CreateComposerZipArtifacts(\ZIP_ARTIFACT_DIR);
     $zipCreator->clearOldArtifacts();


### PR DESCRIPTION
## Proposed Changes

The zip package we create in the test bootstrap to allow for Composer to use the root version of this package when installing needs to have a higher version number than any released version. The version number, however, should also be compatible with the current major.

This updates the version number in the test bootstrap file.

