### PR TITLE
Plugin: use Composer API 2.x methods

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\InstalledVersions;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
@@ -566,6 +567,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function isPHPCodeSnifferInstalled($versionConstraint = null)
     {
+        if ($versionConstraint === null) {
+            return InstalledVersions::isInstalled(self::PACKAGE_NAME);
+        }
+
         return ($this->getPHPCodeSnifferPackage($versionConstraint) !== null);
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -555,7 +555,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getPHPCodeSnifferInstallPath()
     {
-        return $this->composer->getInstallationManager()->getInstallPath($this->getPHPCodeSnifferPackage());
+        return (string) InstalledVersions::getInstallPath(self::PACKAGE_NAME);
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

### Modernize: use InstalledVersions::isInstalled() 

The Composer runtime-api 2.0 introduced the `\Composer\InstalledVersions::isInstalled()` method.

This commit starts using that method.

Implementation choices:
While it would be possible to also handle the version checking via `Composer\InstalledVersions::satisfies(new VersionParser, self::PACKAGE_NAME, (string) $versionConstraint)`, this would require adding a new dependency `"composer/semver": "^3.0"`.
For now, I've chosen not to add the dependency and to leave the pre-existing code for handling version constraints.

Ref: https://getcomposer.org/doc/07-runtime.md#installed-versions

### Modernize: use InstalledVersions::getInstallPath() 

The Composer runtime-api 2.1 introduced the `\Composer\InstalledVersions::getInstallPath()` method.

This commit starts using that method.

Ref: https://getcomposer.org/doc/07-runtime.md#knowing-the-path-in-which-a-package-is-installed

## Related Issues

Follow up on #230

👉🏻 Note: I have another modernization lined up, but am running into a bug in Composer. Holding that one back for now.