### PR TITLE
Tests: run against the *new* PHPCS 4 branch

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -30,6 +30,7 @@
 
     <rule ref="PSR1.Files.SideEffects">
         <exclude-pattern>*/tests/bootstrap\.php$</exclude-pattern>
+        <exclude-pattern>*/tests/fixtures/dummy-subdir/DummySubDir/dummy-autoload\.php$</exclude-pattern>
     </rule>
 
     <!-- Fixture method names in the test classes will be in snake_case because of the PHPUnit Polyfills. -->

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -27,7 +27,7 @@ final class PHPCSVersions
      *
      * @var string
      */
-    const NEXT_MAJOR = '4.0.x-dev as 3.9.99';
+    const NEXT_MAJOR = '4.x-dev as 3.99.99';
 
     /**
      * List of all PHPCS version which are supported by this plugin.

--- a/tests/fixtures/dummy-subdir/DummySubDir/Sniffs/Demo/DemoSniff.php
+++ b/tests/fixtures/dummy-subdir/DummySubDir/Sniffs/Demo/DemoSniff.php
@@ -10,6 +10,9 @@
 
 namespace DummySubDir\Sniffs\Demo;
 
+use PHP_CodeSniffer_File as File;
+use PHP_CodeSniffer_Sniff as PHPCS_Sniff;
+
 /**
  * Dummy sniff which can be used to verify that PHPCS runs with an external standard.
  *
@@ -18,7 +21,7 @@ namespace DummySubDir\Sniffs\Demo;
  * This is to allow the sniff to be compatible with both PHPCS 2.x as well as 3.x
  * without too much other work-arounds being needed.
  */
-class DemoSniff
+class DemoSniff implements PHPCS_Sniff
 {
     /**
      * Registers the tokens that this sniff wants to listen for.
@@ -39,7 +42,7 @@ class DemoSniff
      *
      * @return void
      */
-    public function process($phpcsFile, $stackPtr)
+    public function process(File $phpcsFile, $stackPtr)
     {
         // Do nothing as this is for testing that the sniff can be found only.
     }

--- a/tests/fixtures/dummy-subdir/DummySubDir/dummy-autoload.php
+++ b/tests/fixtures/dummy-subdir/DummySubDir/dummy-autoload.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * PHPCS 2.x Had the `PHP_CodeSniffer_Sniff` interface...
+ * PHPCS 3.x ... renamed that to `PHP_CodeSniffer\Sniffs\Sniff` and ...
+ * PHPCS 4.x ... demands that sniffs implement the interface.
+ *
+ * Additionally, the Ruleset `<autoload>` directive is only supported as of PHPCS 3.0.
+ *
+ * So... for a test fixture "sniff" to be cross-version compatible:
+ * - it must implement the `Sniff` interface for PHPCS 4 compatibility.
+ * - which will need to be class aliased for PHPCS 2 vs 3 compatibility.
+ *   => That's what's being done here.
+ *
+ * Also note that once the interface is being implemented, the `process()` method needs the `File`
+ * type declaration, hence, aliasing that class too.
+ *
+ * And we need to alias to the PHPCS 2.x name as only 3.x can include this autoload file using `<autoload>`.
+ */
+
+if (!defined('PHPCS_ALIASES_SET')) {
+    if (! interface_exists('\PHP_CodeSniffer_File')) {
+        class_alias('PHP_CodeSniffer\Files\File', '\PHP_CodeSniffer_File');
+    }
+
+    if (! class_exists('\PHP_CodeSniffer_Sniff')) {
+        class_alias('PHP_CodeSniffer\Sniffs\Sniff', '\PHP_CodeSniffer_Sniff');
+    }
+
+    define('PHPCS_ALIASES_SET', true);
+}

--- a/tests/fixtures/dummy-subdir/DummySubDir/ruleset.xml
+++ b/tests/fixtures/dummy-subdir/DummySubDir/ruleset.xml
@@ -2,4 +2,6 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DummySubDir" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
+
+    <autoload>/dummy-autoload.php</autoload>
 </ruleset>


### PR DESCRIPTION
## Proposed Changes

The PHP_CodeSniffer 4.0 branch has been completely rebuild. See https://github.com/PHPCSStandards/PHP_CodeSniffer/issues/120 for more detailed information about the "why".

In practice, this means that to test against the upcoming PHPCS 4.0 release, we need to test against the `4.x` branch now, not the old `4.0` branch.

A 4.0 beta/RC release is expected in the next few days. Once that is out, a test period starts and depending on whether problems are found or not, the 4.0.0 release will be tagged about a month later (or later if significant problems were found).

When 4.0.0 gets tagged, the PHPCS `master` branch will be renamed to `3.x` and the `4.x` branch will be the new "main" branch for PHPCS, so more changes will be needed, but that's for later.

Includes updating the `DemoSniff` test fixture setup as PHPCS 4.0 will start enforcing for sniffs to implement the `Sniff` interface.

