### PR TITLE
Test fixture rulesets: update schema URL

### DIFF
--- a/tests/fixtures/dummy-src/src/DummySrcSubDir/ruleset.xml
+++ b/tests/fixtures/dummy-src/src/DummySrcSubDir/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DummySrcSubDir" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DummySrcSubDir" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/dummy-subdir/DummySubDir/ruleset.xml
+++ b/tests/fixtures/dummy-subdir/DummySubDir/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DummySubDir" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="DummySubDir" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/incorrect-type/IncorrectType/ruleset.xml
+++ b/tests/fixtures/incorrect-type/IncorrectType/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="IncorrectType" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="IncorrectType" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/multistandard/My-Third-Standard/ruleset.xml
+++ b/tests/fixtures/multistandard/My-Third-Standard/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="My-Third-Standard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="My-Third-Standard" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/multistandard/MyFirstStandard/ruleset.xml
+++ b/tests/fixtures/multistandard/MyFirstStandard/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MyFirstStandard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MyFirstStandard" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/multistandard/MySecondStandard/ruleset.xml
+++ b/tests/fixtures/multistandard/MySecondStandard/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MySecondStandard" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="MySecondStandard" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>

--- a/tests/fixtures/no-ruleset/NoRuleset/ruleset.xml.dist
+++ b/tests/fixtures/no-ruleset/NoRuleset/ruleset.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NoRuleset" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="NoRuleset" xsi:noNamespaceSchemaLocation="https://schema.phpcodesniffer.com/phpcs.xsd">
 
     <description>Dummy PHPCS standard for testing.</description>
 </ruleset>


### PR DESCRIPTION
## Proposed Changes

PHPCS now offers permalinks for the schema.

Refs:
* PHPCSStandards/PHP_CodeSniffer#1094
* https://github.com/PHPCSStandards/schema.phpcodesniffer.com

