### PR TITLE
Composer: bump PHP Parallel Lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "ext-zip": "*",
     "composer/composer": "^2.2",
     "phpcompatibility/php-compatibility": "^9.0",
-    "php-parallel-lint/php-parallel-lint": "^1.3.1",
+    "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "minimum-stability": "dev",


### PR DESCRIPTION
## Proposed Changes

Mostly to ensure the version installed will be compatible with all PHP version supported by this tool. (v1.4.0 added support for PHP 8.4)

## Related Issues

Ref: https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.4.0
