### PR TITLE
GH Actions: try to fix builds failing due to rate limiting

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -130,6 +130,7 @@ jobs:
           coverage: none
         env:
           fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -38,6 +38,9 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -66,6 +66,7 @@ jobs:
           coverage: none
         env:
           fail-fast: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer


### PR DESCRIPTION
## Proposed Changes

Even though the workflows already set `env: COMPOSER_AUTH` since #200, we are still running into rate limiting issues.

This commit applies the [instruction from `setup-php`](https://github.com/shivammathur/setup-php#github-composer-authentication) on how to solve this. :crossed_fingers:

