### PR TITLE
Fix "The provided cwd "../squizlabs/php_codesniffer" does not exist."

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -555,7 +555,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getPHPCodeSnifferInstallPath()
     {
-        return (string) InstalledVersions::getInstallPath(self::PACKAGE_NAME);
+        return (string) realpath(InstalledVersions::getInstallPath(self::PACKAGE_NAME));
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -555,7 +555,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     private function getPHPCodeSnifferInstallPath()
     {
-        return (string) realpath(InstalledVersions::getInstallPath(self::PACKAGE_NAME));
+        return $this->composer->getInstallationManager()->getInstallPath($this->getPHPCodeSnifferPackage());
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

I'm very curious why the reported issue only appears to happen with a Drupal setup (and I cannot reproduce it, nor do our tests fail). All the same, I'm hoping this will fix it.

Note: yes, `realpath()` can return `false`, but that shouldn't be possible in this case as we only call it after we've already checked `isPHPCodeSnifferInstalled()`.

## Related Issues

Fixed #239 (hopefully)
