### PR TITLE
Fix fatal error when Composer EventDispatcher called programmatically

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,7 +12,6 @@ namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer;
 
 use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
-use Composer\InstalledVersions;
 use Composer\IO\IOInterface;
 use Composer\Package\AliasPackage;
 use Composer\Package\PackageInterface;
@@ -551,6 +550,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Returns the path to the PHP_CodeSniffer package installation location
      *
+     * {@internal Do NOT try to modernize via the Composer 2.2 API (`InstalledVersions::getInstallPath()`).
+     * Doing so doesn't play nice with other plugins.
+     * {@link https://github.com/PHPCSStandards/composer-installer/issues/239}}
+     *
      * @return string
      */
     private function getPHPCodeSnifferInstallPath()
@@ -561,16 +564,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * Simple check if PHP_CodeSniffer is installed.
      *
+     * {@internal Do NOT try to modernize via the Composer 2.2 API (`InstalledVersions::isInstalled()`).
+     * Doing so doesn't play nice with integrations calling the Composer EventDispatcher programmatically.
+     * {@link https://github.com/PHPCSStandards/composer-installer/issues/247}}
+     *
      * @param null|string|\Composer\Semver\Constraint\ConstraintInterface $versionConstraint to match against
      *
      * @return bool Whether PHP_CodeSniffer is installed
      */
     private function isPHPCodeSnifferInstalled($versionConstraint = null)
     {
-        if ($versionConstraint === null) {
-            return InstalledVersions::isInstalled(self::PACKAGE_NAME);
-        }
-
         return ($this->getPHPCodeSnifferPackage($versionConstraint) !== null);
     }
 


### PR DESCRIPTION
## Proposed Changes

This now reverts the second code modernization from #234 as well. Annoying, but so be it.

I've also now added warnings in both places which were modernized and for which the modernizations had to be reverted to hopefully prevent this happening again.


## Related Issues

Fixes #247

## Suggested changelog entry
Fixed
- Potential fatal error when the Composer EventDispatcher is called programmatically from an integration.
