### PR TITLE
Changelog for the 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This projects adheres to [Keep a CHANGELOG](https://keepachangelog.com/) and use
 _Nothing yet._
 
 
+## [v1.1.2] - 2025-07-10
+
+### Changed
+- General housekeeping.
+
+### Fixed
+- [#247]: Potential fatal error when the Composer EventDispatcher is called programmatically from an integration. Thanks [@jrfnl] ! [#248]
+
+[#247]:  https://github.com/PHPCSStandards/composer-installer/issues/247
+[#248]:  https://github.com/PHPCSStandards/composer-installer/pull/248
+
+
 ## [v1.1.1] - 2025-06-27
 
 ### Changed
@@ -519,6 +531,7 @@ For this version on, this installer no longer messes with the installation paths
 
 First useable release.
 
+[v1.1.2]: https://github.com/PHPCSStandards/composer-installer/compare/v1.1.1...v1.1.2
 [v1.1.1]: https://github.com/PHPCSStandards/composer-installer/compare/v1.1.0...v1.1.1
 [v1.1.0]: https://github.com/PHPCSStandards/composer-installer/compare/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/PHPCSStandards/composer-installer/compare/v0.7.2...v1.0.0


### PR DESCRIPTION
This PR presumes that PR #248 will be accepted and will be released straight away as v 1.1.2.

@Potherca If you have no objections, I will do the release once I've received approvals on both this PR and PR #248.

---

## Release checklist

### General

- [x] Verify, and if necessary, update the allowed version ranges for various dependencies in the `composer.json` - Verified, not needed.

### Release Preparation

- [x] Make sure all closed tickets and PRs have a label.
- [x] Make sure all closed tickets and PRs are added to the milestone that is to be released.
- [x] Add changelog for the release to the `CHANGELOG.md` file based on the tickets in the current milestone and submit as PR - PR #249
    - 💡 Keep in mind, changelogs are for humans, not for machines.
    - 📝 Remember to add a release diff link at the bottom!
    - 📝 Handy: use this checklist as the PR description to document the release.

### Milestone

- [x] Close the milestone.
- [x] Open a new milestone for the next release.
- [x] If any open PRs/issues which were milestoned for this release did not make it into the release, update their milestone.

### Release

- [x] Merge the changelog PR.
- [x] Make sure all CI builds are green.
- [x] Tag and create a release against the `main` branch and copy & paste the changelog to it.
    - 📝 Use the "Auto-generate changelog" button to get GitHub to create a "New contributors" section and the release diff link. Keep those, remove everything else auto-generated and replace it with the manually crafted changelog for humans.
    - 📝 Check if anything from the link collection at the bottom of the `changelog.md` file needs to be copied in!
- [x] Make sure all CI builds are green.

### Publicize

- [x] Toot about the release. https://phpc.social/@phpcs/114870673589333384
- [x] Tweet about the release. https://x.com/PHP_CodeSniffer/status/1945957683351228544
