### PR TITLE
Tests: fix two missing import `use` statements

### DIFF
--- a/tests/IntegrationTest/NonInstallUpdateEventsTest.php
+++ b/tests/IntegrationTest/NonInstallUpdateEventsTest.php
@@ -12,6 +12,7 @@ namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\Integra
 
 use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Plugin;
 use PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests\TestCase;
+use RuntimeException;
 
 /**
  * Test that the plugin doesn't get triggered on events it isn't hooked into.

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -10,6 +10,8 @@
 
 namespace PHPCSStandards\Composer\Plugin\Installers\PHPCodeSniffer\Tests;
 
+use RuntimeException;
+
 /**
  * Helper class to retrieve PHPCS versions suitable for the current PHP version.
  */


### PR DESCRIPTION
## Proposed Changes

Add two import `use` statements for the PHP native `RuntimeException` class, which is used to signal certain failures in the test set up.

The fact that this wasn't noticed before clearly means the tests never failed at those Exceptions before ;-)


## Suggested changelog entry
_N/A_ (general housekeeping)