### PR TITLE
GH Actions: remove GH Token set via `env`

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -130,7 +130,6 @@ jobs:
           coverage: none
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -40,7 +40,6 @@ jobs:
           tools: cs2pr
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -66,7 +66,6 @@ jobs:
           coverage: none
         env:
           fail-fast: true
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer


### PR DESCRIPTION
## Proposed Changes

As of the release of `shivammathur/setup-php` v`2.35.0`, this should no longer be needed as the `setup-php` action runner will automatically use the `secrets.GITHUB_TOKEN` token.

## Related Issues

Ref:
* https://github.com/shivammathur/setup-php/releases/tag/2.35.0
* https://github.com/shivammathur/setup-php/commit/55463ffe4fef24b158d1d7f861dce8b7d3811c13

## Suggested changelog entry
_N/A_