### PR TITLE
README: update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ After running `composer install` PHP_CodeSniffer just works:
 
 ```bash
 $ ./vendor/bin/phpcs -i
-The installed coding standards are MySource, PEAR, PSR1, PSR2, PSR12, Squiz, Zend, PHPCompatibility,
-Modernize, NormalizedArrays, Universal, PHPCSUtils, WordPress, WordPress-Core, WordPress-Docs and WordPress-Extra
+The installed coding standards are PEAR, PSR1, PSR2, PSR12, Squiz, Zend, PHPCompatibility, Modernize,
+NormalizedArrays, Universal, PHPCSUtils, WordPress, WordPress-Core, WordPress-Docs and WordPress-Extra
 ```
 
 ### Calling the plugin directly


### PR DESCRIPTION
## Proposed Changes

The [Object Calisthenics](https://github.com/object-calisthenics/phpcs-calisthenics-rules) project has been deprecated/abandoned, so I don't think mentioning it in the example is a good idea.

Aside from that, both PHPCompatibility and WordPressCS now have new dependencies which register additional standards with PHPCS, so the example output was outdated too.

Lastly, let's update the PHPCS version used in another example to a more recent one.

## Suggested changelog entry
* Updated documentation