### PR TITLE
Tests/bootstrap: fix custom autoloader for running with PHAR file

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,7 +52,7 @@ if (\defined('__PHPUNIT_PHAR__')) {
         }
 
         // Strip namespace prefix.
-        $relativeClass = \substr($className, 61);
+        $relativeClass = \substr($className, 63);
         $file          = \realpath(__DIR__) . \DIRECTORY_SEPARATOR
             . \strtr($relativeClass, '\\', \DIRECTORY_SEPARATOR) . '.php';
 


### PR DESCRIPTION
## Proposed Changes

This was broken after #191, when the namespace prefix was changed from `DealerDirect` (12 chars) to `PHPCSStandards` (14 chars).

As the tests in CI don't use the PHPUnit PHAR file, this went unnoticed.

## Suggested changelog entry
_N/A_ (test only change)