### PR TITLE
Tests/PHPCSVersions: update for branching of PHP 8.5

### DIFF
--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -414,9 +414,19 @@ final class PHPCSVersions
                 break;
 
             case '8.5':
+                $versions = array_filter(
+                    self::$allPhpcsVersions,
+                    static function ($version) {
+                        // PHPCS 3.13.4 is the first PHPCS version with runtime support for PHP 8.5.
+                        return version_compare($version, '3.13.4', '>=');
+                    }
+                );
+                break;
+
+            case '8.6':
                 /*
-                 * At this point in time, it is unclear as of which PHPCS version PHP 8.5 will be supported.
-                 * In other words: tests should only use dev-master/4.x when on PHP 8.5 for the time being.
+                 * At this point in time, it is unclear as of which PHPCS version PHP 8.6 will be supported.
+                 * In other words: tests should only use 4.x-dev when on PHP 8.6 for the time being.
                  */
                 $versions = array();
                 break;


### PR DESCRIPTION
## Proposed Changes

The PHP project has branched off PHP 8.5, which is now in RC and PHP "master/nightly" is now what will become PHP 8.6 (or possible 9.0).

As PHP 8.5 is now in RC, only bug fixes are allowed in, so no new deprecation notices are expected anymore.

PHPCS has already released new versions fixing various PHP 8.5 deprecation notices, so PHPCS 3.13.4 can be presumed to be the first PHPCS version which is runtime compatible with PHP 8.5.

Having said that, we could go back further as the functionality used by this plugin/the tests for this plugin would not be affected by the PHP 8.5 deprecation notices which affected PHPCS. Then again, for consistency, let's stick with the "official" PHPCS version with runtime support for PHP 8.5.

Refs:
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.13.4
* https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/4.0.0


## Suggested changelog entry
_N/A_ (test only change)