### PR TITLE
Composer/CS: update to PHPCompatibility 10.0.0-alpha1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "ext-json": "*",
     "ext-zip": "*",
     "composer/composer": "^2.2",
-    "phpcompatibility/php-compatibility": "^9.0",
+    "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
     "php-parallel-lint/php-parallel-lint": "^1.4.0",
     "yoast/phpunit-polyfills": "^1.0"
   },


### PR DESCRIPTION
## Proposed Changes

PHPCompatibility has released a new version: 10.0.0-alpha1.

Even though this is an alpha version, it still offers significant improvements compared to the last 9.x release (from 2019), so I'd strongly recommend switching over to improve our safeguarding against introduction of PHP cross-version incompatible code.

Note: the version restraints in the `composer.json` are widened instead of bumped to prevent us running into install problems when testing against a wide range of PHPCS versions, as the minimum PHPCS version of PHPCompatibility 10 is currently PHPCS 3.13.3, which is much higher than our own minimum PHPCS version. PHPCompatibility 9.x still supports PHPCS 2.x (and 3.x), so allowing both 9 + 10 should prevent issues and should still run the CS check using PHPCompatibility 10.

Ref:
* https://github.com/PHPCompatibility/PHPCompatibility/releases/tag/10.0.0-alpha1

## Suggested changelog entry
_N/A_