### PR TITLE
GH Actions/securitycheck: only run against PHP 5.4

### DIFF
--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', 'latest']
+        php: ['5.4']
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Proposed Changes

As of Composer 2.9, using this type of security check is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

However, Composer 2.9 requires PHP 7.2, so we should continue to run the security check for PHP 5.4 for the time being, but we can stop running the check against PHP "latest".

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0


## Suggested changelog entry
_N/A_ (CI only change)