### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -40,6 +40,7 @@ jobs:
           - '8.3'
           - '8.4'
           - '8.5'
+          - '8.6'
         composer:
           - 'v2'
         os:
@@ -114,7 +115,7 @@ jobs:
 
     name: "Integration test"
 
-    continue-on-error: ${{ matrix.php == '8.5' || matrix.composer == 'snapshot' }}
+    continue-on-error: ${{ matrix.php == '8.6' || matrix.composer == 'snapshot' }}
 
     steps:
       - name: Checkout code
@@ -136,7 +137,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install Composer dependencies
-        if: ${{ matrix.php != '8.5' }}
+        if: ${{ matrix.php != '8.6' }}
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           composer-options: '--optimize-autoloader'
@@ -144,7 +145,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install Composer dependencies
-        if: ${{ matrix.php == '8.5' }}
+        if: ${{ matrix.php == '8.6' }}
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           composer-options: '--ignore-platform-reqs --optimize-autoloader'


### PR DESCRIPTION
## Proposed Changes

Update for the release of PHP 8.5 which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.6.


## Suggested changelog entry
_N/A_ (CI only change)
