### PR TITLE
Resolve relative paths to absolute before validation to avoid open_basedir warnings

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -409,12 +409,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $alternativePath = realpath($this->getPHPCodeSnifferInstallPath() . \DIRECTORY_SEPARATOR . $path);
 
             if (
-                (is_dir($path) === false || is_readable($path) === false) &&
                 (
                     $alternativePath === false ||
                     is_dir($alternativePath) === false ||
                     is_readable($alternativePath) === false
-                )
+                ) &&
+                (is_dir($path) === false || is_readable($path) === false)
             ) {
                 unset($this->installedPaths[$key]);
                 $changes = true;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -405,17 +405,13 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $changes = false;
         foreach ($this->installedPaths as $key => $path) {
-            // This might be a relative path as well
-            $alternativePath = realpath($this->getPHPCodeSnifferInstallPath() . \DIRECTORY_SEPARATOR . $path);
+            // Resolve relative paths against the PHPCS install path before validation
+            // to avoid open_basedir warnings from is_dir() on raw relative paths.
+            if ($this->filesystem->isAbsolutePath($path) === false) {
+                $path = realpath($this->getPHPCodeSnifferInstallPath() . \DIRECTORY_SEPARATOR . $path);
+            }
 
-            if (
-                (
-                    $alternativePath === false ||
-                    is_dir($alternativePath) === false ||
-                    is_readable($alternativePath) === false
-                ) &&
-                (is_dir($path) === false || is_readable($path) === false)
-            ) {
+            if ($path === false || is_dir($path) === false || is_readable($path) === false) {
                 unset($this->installedPaths[$key]);
                 $changes = true;
             }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -405,8 +405,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         $changes = false;
         foreach ($this->installedPaths as $key => $path) {
-            // Resolve relative paths against the PHPCS install path before validation
-            // to avoid open_basedir warnings from is_dir() on raw relative paths.
+            // Resolve relative paths to absolute using the PHPCS install path as the base
+            // to avoid potential open_basedir warnings from is_dir() on relative paths.
             if ($this->filesystem->isAbsolutePath($path) === false) {
                 $path = realpath($this->getPHPCodeSnifferInstallPath() . \DIRECTORY_SEPARATOR . $path);
             }

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -278,6 +278,237 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
     }
 
     /**
+     * Test correctly handling a pre-existing PHPCS configuration file which includes both
+     * a pre-set, valid path, as well as an invalid absolute path in `installed_paths`.
+     *
+     * @dataProvider dataPHPCSVersions
+     *
+     * @param string $phpcsVersion  PHPCS version to use in this test.
+     *                              This version is randomly selected from the PHPCS versions compatible
+     *                              with the PHP version used in the test.
+     *
+     * @return void
+     */
+    public function testPreexistingInvalidAbsoluteInstalledPathsConfigIsRemoved($phpcsVersion)
+    {
+        $config = $this->composerConfig;
+        $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
+
+        $this->writeComposerJsonFile($config, static::$tempLocalPath);
+
+        /*
+         * 1. Install PHPCS and the plugin.
+         */
+        $this->assertExecute(
+            sprintf('composer install -v --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
+            0,    // Expected exit code.
+            null, // No stdout expectation.
+            null, // No stderr expectation.
+            'Failed to install PHPCS.'
+        );
+
+        /*
+         * 2. Set the installed_paths and verify it is registered correctly.
+         */
+        $command = sprintf(
+            '"vendor/bin/phpcs" --config-set installed_paths %s',
+            escapeshellarg($this->tempExtraStndsPath)
+        );
+        $result  = $this->executeCliCommand($command, static::$tempLocalPath);
+        $this->assertSame(
+            0,
+            $result['exitcode'],
+            'Exitcode for "phpcs --config-set installed_paths" did not match 0'
+        );
+
+        /*
+         * Manipulate the value of installed_paths to add an invalid absolute path.
+         */
+        $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
+        $confContents = file_get_contents($confFile);
+        $this->assertNotFalse($confContents);
+        $confContents = str_replace(
+            $this->tempExtraStndsSubdir,
+            $this->tempExtraStndsSubdir . ',/nonexistent/absolute/path/to/standard',
+            $confContents
+        );
+        $this->assertNotFalse(file_put_contents($confFile, $confContents));
+
+        // Verify that the config contains the newly set value.
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (first run)');
+
+        $expected = array(
+            $this->tempExtraStndsPath,
+            '/nonexistent/absolute/path/to/standard',
+        );
+        sort($expected, \SORT_NATURAL);
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'PHPCS configuration does not show the manually set installed_paths correctly'
+        );
+
+        /*
+         * 3. Install an external standard.
+         */
+        $command = sprintf(
+            'composer require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v --working-dir=%s',
+            escapeshellarg(static::$tempLocalPath)
+        );
+        $this->assertExecute(
+            $command,
+            0,    // Expected exit code.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
+            null, // No stderr expectation.
+            'Failed to install Dummy subdir standard.'
+        );
+
+        /*
+         * Verify that the valid preset path is retained, that the invalid absolute path is removed
+         * and the new standard is registered correctly.
+         */
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (second run)');
+
+        $expected = array(
+            $this->tempExtraStndsPath,
+            '/phpcs-composer-installer/dummy-subdir',
+        );
+        sort($expected, \SORT_NATURAL);
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'Paths as updated by the plugin does not contain the expected paths'
+        );
+    }
+
+    /**
+     * Test correctly handling a pre-existing PHPCS configuration file which includes
+     * a pre-set, valid relative path in `installed_paths`.
+     *
+     * @dataProvider dataPHPCSVersions
+     *
+     * @param string $phpcsVersion  PHPCS version to use in this test.
+     *                              This version is randomly selected from the PHPCS versions compatible
+     *                              with the PHP version used in the test.
+     *
+     * @return void
+     */
+    public function testPreexistingValidRelativeInstalledPathsConfigIsKept($phpcsVersion)
+    {
+        $config = $this->composerConfig;
+        $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
+
+        $this->writeComposerJsonFile($config, static::$tempLocalPath);
+
+        /*
+         * 1. Install PHPCS and the plugin.
+         */
+        $this->assertExecute(
+            sprintf('composer install -v --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
+            0,    // Expected exit code.
+            null, // No stdout expectation.
+            null, // No stderr expectation.
+            'Failed to install PHPCS.'
+        );
+
+        /*
+         * 2. Create a valid standard inside the vendor directory and set it as a relative path.
+         *
+         * The standard is placed at "vendor/test-extra-stnd/TestExtraStnd/" so that the relative
+         * path from the PHPCS install dir (vendor/squizlabs/php_codesniffer) is "../../test-extra-stnd".
+         */
+        $extraStndInVendor = static::$tempLocalPath . '/vendor/test-extra-stnd/TestExtraStnd';
+        if (mkdir($extraStndInVendor, 0766, true) === false || is_dir($extraStndInVendor) === false) {
+            throw new RuntimeException("Failed to create the $extraStndInVendor directory for the test");
+        }
+
+        file_put_contents(
+            $extraStndInVendor . '/ruleset.xml',
+            '<?xml version="1.0"?>' . \PHP_EOL
+            . '<ruleset name="TestExtraStnd">' . \PHP_EOL
+            . '    <description>Test standard for valid relative path testing.</description>' . \PHP_EOL
+            . '</ruleset>' . \PHP_EOL
+        );
+
+        /*
+         * Set a valid absolute path first via --config-set, then convert it to a relative path
+         * by editing the config file directly. This avoids potential PHPCS validation issues
+         * with relative paths passed to --config-set.
+         */
+        $absoluteStndPath = static::$tempLocalPath . '/vendor/test-extra-stnd';
+        $relativeStndPath = '../../test-extra-stnd';
+
+        $command = sprintf(
+            '"vendor/bin/phpcs" --config-set installed_paths %s',
+            escapeshellarg($absoluteStndPath)
+        );
+        $result = $this->executeCliCommand($command, static::$tempLocalPath);
+        $this->assertSame(
+            0,
+            $result['exitcode'],
+            'Exitcode for "phpcs --config-set installed_paths" did not match 0'
+        );
+
+        // Replace the absolute path with a relative path in the config file.
+        $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
+        $confContents = file_get_contents($confFile);
+        $this->assertNotFalse($confContents);
+        $confContents = str_replace($absoluteStndPath, $relativeStndPath, $confContents);
+        $this->assertNotFalse(file_put_contents($confFile, $confContents));
+
+        // Verify that the config contains the relative path.
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (first run)');
+
+        $expected = array(
+            '/test-extra-stnd',
+        );
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'PHPCS configuration does not show the manually set relative installed_paths correctly'
+        );
+
+        /*
+         * 3. Install an external standard.
+         */
+        $command = sprintf(
+            'composer require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v --working-dir=%s',
+            escapeshellarg(static::$tempLocalPath)
+        );
+        $this->assertExecute(
+            $command,
+            0,    // Expected exit code.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
+            null, // No stderr expectation.
+            'Failed to install Dummy subdir standard.'
+        );
+
+        /*
+         * Verify that the valid relative path is retained and the new standard is registered correctly.
+         */
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (second run)');
+
+        $expected = array(
+            '/phpcs-composer-installer/dummy-subdir',
+            '/test-extra-stnd',
+        );
+        sort($expected, \SORT_NATURAL);
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'Paths as updated by the plugin does not contain the expected paths'
+        );
+    }
+
+    /**
      * Data provider.
      *
      * @return array

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -446,7 +446,7 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
             '"vendor/bin/phpcs" --config-set installed_paths %s',
             escapeshellarg($absoluteStndPath)
         );
-        $result = $this->executeCliCommand($command, static::$tempLocalPath);
+        $result  = $this->executeCliCommand($command, static::$tempLocalPath);
         $this->assertSame(
             0,
             $result['exitcode'],

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -74,6 +74,137 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
     }
 
     /**
+     * Test correctly handling a pre-existing PHPCS configuration file which includes
+     * a pre-set, valid relative path in `installed_paths`.
+     *
+     * @dataProvider dataPHPCSVersions
+     *
+     * @param string $phpcsVersion  PHPCS version to use in this test.
+     *                              This version is randomly selected from the PHPCS versions compatible
+     *                              with the PHP version used in the test.
+     *
+     * @return void
+     */
+    public function testPreexistingValidRelativeInstalledPathsConfigIsKeptIntact($phpcsVersion)
+    {
+        $config = $this->composerConfig;
+        $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
+
+        $this->writeComposerJsonFile($config, static::$tempLocalPath);
+
+        /*
+         * 1. Install PHPCS and the plugin.
+         */
+        $this->assertExecute(
+            sprintf('composer install -v --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
+            0,    // Expected exit code.
+            null, // No stdout expectation.
+            null, // No stderr expectation.
+            'Failed to install PHPCS.'
+        );
+
+        /*
+         * 2. Create a valid standard inside the vendor directory and set it as a relative path.
+         *
+         * The standard is placed at "vendor/test-extra-stnd/TestExtraStnd/" so that the relative
+         * path from the PHPCS install dir (vendor/squizlabs/php_codesniffer) is "../../test-extra-stnd".
+         */
+        $extraStndInVendor = static::$tempLocalPath . '/vendor/test-extra-stnd/TestExtraStnd';
+        $this->assertNotFalse(
+            mkdir($extraStndInVendor, 0766, true),
+            "Failed to create the $extraStndInVendor directory for the test"
+        );
+        $this->assertDirectoryExists($extraStndInVendor);
+
+        $this->assertNotFalse(
+            file_put_contents(
+                $extraStndInVendor . '/ruleset.xml',
+                '<?xml version="1.0"?>' . \PHP_EOL
+                . '<ruleset name="TestExtraStnd">' . \PHP_EOL
+                . '    <description>Test standard for valid relative path testing.</description>' . \PHP_EOL
+                . '</ruleset>' . \PHP_EOL
+            ),
+            'Failed to create the ruleset.xml fixture file'
+        );
+
+        /*
+         * Set a valid absolute path first via --config-set, then convert it to a relative path
+         * by editing the config file directly. This avoids potential PHPCS validation issues
+         * with relative paths passed to --config-set.
+         */
+        $absoluteStndPath = static::$tempLocalPath . '/vendor/test-extra-stnd';
+        $relativeStndPath = '../../test-extra-stnd';
+
+        $command = sprintf(
+            '"vendor/bin/phpcs" --config-set installed_paths %s',
+            escapeshellarg($absoluteStndPath)
+        );
+        $result  = $this->executeCliCommand($command, static::$tempLocalPath);
+        $this->assertSame(
+            0,
+            $result['exitcode'],
+            'Exitcode for "phpcs --config-set installed_paths" did not match 0'
+        );
+
+        // Replace the absolute path with a relative path in the config file.
+        $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
+        $confContents = file_get_contents($confFile);
+        $this->assertNotFalse($confContents, 'Failed to read the PHPCS configuration file');
+        $confContents = str_replace($absoluteStndPath, $relativeStndPath, $confContents);
+        $this->assertNotFalse(
+            file_put_contents($confFile, $confContents),
+            'Failed to write the PHPCS configuration file'
+        );
+
+        // Verify that the config contains the relative path.
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (first run)');
+
+        $expected = array(
+            '/test-extra-stnd',
+        );
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'PHPCS configuration does not show the manually set relative installed_paths correctly'
+        );
+
+        /*
+         * 3. Install an external standard.
+         */
+        $command = sprintf(
+            'composer require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v --working-dir=%s',
+            escapeshellarg(static::$tempLocalPath)
+        );
+        $this->assertExecute(
+            $command,
+            0,    // Expected exit code.
+            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
+            null, // No stderr expectation.
+            'Failed to install Dummy subdir standard.'
+        );
+
+        /*
+         * Verify that the valid relative path is retained and the new standard is registered correctly.
+         */
+        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
+        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (second run)');
+
+        $expected = array(
+            '/phpcs-composer-installer/dummy-subdir',
+            '/test-extra-stnd',
+        );
+        sort($expected, \SORT_NATURAL);
+
+        $this->assertSame(
+            $expected,
+            $this->configShowToPathsArray($result['stdout']),
+            'Paths as updated by the plugin does not contain the expected paths'
+        );
+    }
+
+    /**
      * Test correctly handling a pre-existing PHPCS configuration file which includes a pre-set,
      * valid absolute path in `installed_paths`.
      *
@@ -381,137 +512,6 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
         $expected = array(
             $this->tempExtraStndsPath,
             '/phpcs-composer-installer/dummy-subdir',
-        );
-        sort($expected, \SORT_NATURAL);
-
-        $this->assertSame(
-            $expected,
-            $this->configShowToPathsArray($result['stdout']),
-            'Paths as updated by the plugin does not contain the expected paths'
-        );
-    }
-
-    /**
-     * Test correctly handling a pre-existing PHPCS configuration file which includes
-     * a pre-set, valid relative path in `installed_paths`.
-     *
-     * @dataProvider dataPHPCSVersions
-     *
-     * @param string $phpcsVersion  PHPCS version to use in this test.
-     *                              This version is randomly selected from the PHPCS versions compatible
-     *                              with the PHP version used in the test.
-     *
-     * @return void
-     */
-    public function testPreexistingValidRelativeInstalledPathsConfigIsKept($phpcsVersion)
-    {
-        $config = $this->composerConfig;
-        $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
-
-        $this->writeComposerJsonFile($config, static::$tempLocalPath);
-
-        /*
-         * 1. Install PHPCS and the plugin.
-         */
-        $this->assertExecute(
-            sprintf('composer install -v --working-dir=%s', escapeshellarg(static::$tempLocalPath)),
-            0,    // Expected exit code.
-            null, // No stdout expectation.
-            null, // No stderr expectation.
-            'Failed to install PHPCS.'
-        );
-
-        /*
-         * 2. Create a valid standard inside the vendor directory and set it as a relative path.
-         *
-         * The standard is placed at "vendor/test-extra-stnd/TestExtraStnd/" so that the relative
-         * path from the PHPCS install dir (vendor/squizlabs/php_codesniffer) is "../../test-extra-stnd".
-         */
-        $extraStndInVendor = static::$tempLocalPath . '/vendor/test-extra-stnd/TestExtraStnd';
-        $this->assertNotFalse(
-            mkdir($extraStndInVendor, 0766, true),
-            "Failed to create the $extraStndInVendor directory for the test"
-        );
-        $this->assertDirectoryExists($extraStndInVendor);
-
-        $this->assertNotFalse(
-            file_put_contents(
-                $extraStndInVendor . '/ruleset.xml',
-                '<?xml version="1.0"?>' . \PHP_EOL
-                . '<ruleset name="TestExtraStnd">' . \PHP_EOL
-                . '    <description>Test standard for valid relative path testing.</description>' . \PHP_EOL
-                . '</ruleset>' . \PHP_EOL
-            ),
-            'Failed to create the ruleset.xml fixture file'
-        );
-
-        /*
-         * Set a valid absolute path first via --config-set, then convert it to a relative path
-         * by editing the config file directly. This avoids potential PHPCS validation issues
-         * with relative paths passed to --config-set.
-         */
-        $absoluteStndPath = static::$tempLocalPath . '/vendor/test-extra-stnd';
-        $relativeStndPath = '../../test-extra-stnd';
-
-        $command = sprintf(
-            '"vendor/bin/phpcs" --config-set installed_paths %s',
-            escapeshellarg($absoluteStndPath)
-        );
-        $result  = $this->executeCliCommand($command, static::$tempLocalPath);
-        $this->assertSame(
-            0,
-            $result['exitcode'],
-            'Exitcode for "phpcs --config-set installed_paths" did not match 0'
-        );
-
-        // Replace the absolute path with a relative path in the config file.
-        $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
-        $confContents = file_get_contents($confFile);
-        $this->assertNotFalse($confContents, 'Failed to read the PHPCS configuration file');
-        $confContents = str_replace($absoluteStndPath, $relativeStndPath, $confContents);
-        $this->assertNotFalse(
-            file_put_contents($confFile, $confContents),
-            'Failed to write the PHPCS configuration file'
-        );
-
-        // Verify that the config contains the relative path.
-        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
-        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (first run)');
-
-        $expected = array(
-            '/test-extra-stnd',
-        );
-
-        $this->assertSame(
-            $expected,
-            $this->configShowToPathsArray($result['stdout']),
-            'PHPCS configuration does not show the manually set relative installed_paths correctly'
-        );
-
-        /*
-         * 3. Install an external standard.
-         */
-        $command = sprintf(
-            'composer require --dev phpcs-composer-installer/dummy-subdir --no-ansi -v --working-dir=%s',
-            escapeshellarg(static::$tempLocalPath)
-        );
-        $this->assertExecute(
-            $command,
-            0,    // Expected exit code.
-            'PHP CodeSniffer Config installed_paths set to ', // Expectation for stdout.
-            null, // No stderr expectation.
-            'Failed to install Dummy subdir standard.'
-        );
-
-        /*
-         * Verify that the valid relative path is retained and the new standard is registered correctly.
-         */
-        $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
-        $this->assertSame(0, $result['exitcode'], 'Exitcode for "phpcs --config-show" did not match 0 (second run)');
-
-        $expected = array(
-            '/phpcs-composer-installer/dummy-subdir',
-            '/test-extra-stnd',
         );
         sort($expected, \SORT_NATURAL);
 

--- a/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
+++ b/tests/IntegrationTest/PreexistingPHPCSInstalledPathsConfigTest.php
@@ -75,7 +75,7 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
 
     /**
      * Test correctly handling a pre-existing PHPCS configuration file which includes a pre-set,
-     * valid `installed_paths`.
+     * valid absolute path in `installed_paths`.
      *
      * @dataProvider dataPHPCSVersions
      *
@@ -85,7 +85,7 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
      *
      * @return void
      */
-    public function testPreexistingValidInstalledPathsConfigIsKeptIntact($phpcsVersion)
+    public function testPreexistingValidAbsoluteInstalledPathsConfigIsKeptIntact($phpcsVersion)
     {
         $config = $this->composerConfig;
         $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
@@ -163,7 +163,7 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
 
     /**
      * Test correctly handling a pre-existing PHPCS configuration file which includes both
-     * a pre-set, valid path, as well as an invalid path in `installed_paths`.
+     * a pre-set, valid path, as well as an invalid relative path in `installed_paths`.
      *
      * @dataProvider dataPHPCSVersions
      *
@@ -173,7 +173,7 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
      *
      * @return void
      */
-    public function testPreexistingInvalidInstalledPathsConfigIsRemoved($phpcsVersion)
+    public function testPreexistingInvalidRelativeInstalledPathsConfigIsRemoved($phpcsVersion)
     {
         $config = $this->composerConfig;
         $config['require-dev']['squizlabs/php_codesniffer'] = $phpcsVersion;
@@ -218,13 +218,16 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
          */
         $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
         $confContents = file_get_contents($confFile);
-        $this->assertNotFalse($confContents);
+        $this->assertNotFalse($confContents, 'Failed to read the PHPCS configuration file');
         $confContents = str_replace(
             $this->tempExtraStndsSubdir,
             $this->tempExtraStndsSubdir . ',path/to/somecloned-stnd',
             $confContents
         );
-        $this->assertNotFalse(file_put_contents($confFile, $confContents));
+        $this->assertNotFalse(
+            file_put_contents($confFile, $confContents),
+            'Failed to write the PHPCS configuration file'
+        );
 
         // Verify that the config contains the newly set value.
         $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
@@ -326,13 +329,16 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
          */
         $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
         $confContents = file_get_contents($confFile);
-        $this->assertNotFalse($confContents);
+        $this->assertNotFalse($confContents, 'Failed to read the PHPCS configuration file');
         $confContents = str_replace(
             $this->tempExtraStndsSubdir,
             $this->tempExtraStndsSubdir . ',/nonexistent/absolute/path/to/standard',
             $confContents
         );
-        $this->assertNotFalse(file_put_contents($confFile, $confContents));
+        $this->assertNotFalse(
+            file_put_contents($confFile, $confContents),
+            'Failed to write the PHPCS configuration file'
+        );
 
         // Verify that the config contains the newly set value.
         $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);
@@ -422,16 +428,21 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
          * path from the PHPCS install dir (vendor/squizlabs/php_codesniffer) is "../../test-extra-stnd".
          */
         $extraStndInVendor = static::$tempLocalPath . '/vendor/test-extra-stnd/TestExtraStnd';
-        if (mkdir($extraStndInVendor, 0766, true) === false || is_dir($extraStndInVendor) === false) {
-            throw new RuntimeException("Failed to create the $extraStndInVendor directory for the test");
-        }
+        $this->assertNotFalse(
+            mkdir($extraStndInVendor, 0766, true),
+            "Failed to create the $extraStndInVendor directory for the test"
+        );
+        $this->assertDirectoryExists($extraStndInVendor);
 
-        file_put_contents(
-            $extraStndInVendor . '/ruleset.xml',
-            '<?xml version="1.0"?>' . \PHP_EOL
-            . '<ruleset name="TestExtraStnd">' . \PHP_EOL
-            . '    <description>Test standard for valid relative path testing.</description>' . \PHP_EOL
-            . '</ruleset>' . \PHP_EOL
+        $this->assertNotFalse(
+            file_put_contents(
+                $extraStndInVendor . '/ruleset.xml',
+                '<?xml version="1.0"?>' . \PHP_EOL
+                . '<ruleset name="TestExtraStnd">' . \PHP_EOL
+                . '    <description>Test standard for valid relative path testing.</description>' . \PHP_EOL
+                . '</ruleset>' . \PHP_EOL
+            ),
+            'Failed to create the ruleset.xml fixture file'
         );
 
         /*
@@ -456,9 +467,12 @@ final class PreexistingPHPCSInstalledPathsConfigTest extends TestCase
         // Replace the absolute path with a relative path in the config file.
         $confFile     = static::$tempLocalPath . '/vendor/squizlabs/php_codesniffer/CodeSniffer.conf';
         $confContents = file_get_contents($confFile);
-        $this->assertNotFalse($confContents);
+        $this->assertNotFalse($confContents, 'Failed to read the PHPCS configuration file');
         $confContents = str_replace($absoluteStndPath, $relativeStndPath, $confContents);
-        $this->assertNotFalse(file_put_contents($confFile, $confContents));
+        $this->assertNotFalse(
+            file_put_contents($confFile, $confContents),
+            'Failed to write the PHPCS configuration file'
+        );
 
         // Verify that the config contains the relative path.
         $result = $this->executeCliCommand('"vendor/bin/phpcs" --config-show', static::$tempLocalPath);


### PR DESCRIPTION
When `installed_paths` in the PHPCS configuration contains relative paths, subsequent `composer install` runs can trigger PHP `open_basedir` restriction warnings. This happens because `is_dir()` is called directly on the relative path, which may fall outside the allowed `open_basedir` directories.

## Proposed Changes

Resolve relative paths to absolute paths (using the PHPCS install path as the base directory) before validating them with `is_dir()` and `is_readable()`. This ensures path checks operate on fully qualified paths that respect `open_basedir` restrictions.

## Related Issues

Closes #271

## Suggested changelog entry
fix for open_basedir error during composer install
