### PR TITLE
GH Actions/linting: lint XML files

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Validate composer.json and composer.lock
+      - name: Validate composer.json
         uses: "docker://composer"
         with:
           args: "composer validate --no-check-lock"
@@ -61,3 +61,33 @@ jobs:
           persist-credentials: false
       - name: Check markdown
         uses: pipeline-components/remark-lint@master
+
+  lint-xml:
+    name: Check XML files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # Validate dev tool related XML files.
+      - name: Validate Project PHPCS ruleset against schema
+        uses: phpcsstandards/xmllint-validate@0fd9c4a9046055f621fca4bbdccb8eab1fd59fdc # v1.0.1
+        with:
+          pattern: phpcs.xml.dist
+          xsd-url: https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/refs/heads/4.x/phpcs.xsd
+
+      - name: Validate PHPUnit config against schema
+        uses: phpcsstandards/xmllint-validate@0fd9c4a9046055f621fca4bbdccb8eab1fd59fdc # v1.0.1
+        with:
+          pattern: phpunit.xml.dist
+          xsd-url: https://raw.githubusercontent.com/sebastianbergmann/phpunit/refs/heads/main/schema/9.2.xsd
+
+      # Validate the XML ruleset files used in the tests.
+      - name: Validate rulesets against schema
+        uses: phpcsstandards/xmllint-validate@0fd9c4a9046055f621fca4bbdccb8eab1fd59fdc # v1.0.1
+        with:
+          pattern: tests/fixtures/*/*/ruleset.xml
+          xsd-url: https://raw.githubusercontent.com/PHPCSStandards/PHP_CodeSniffer/refs/heads/4.x/phpcs.xsd

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,7 @@ The non-PHP specific tools used by this build are:
 - [jsonlint][] to verify that all JSON files use a consistent code style.
 - [remark-lint][] to verify that all markdown files use a consistent code style.
 - [yamllint][] to verify that all Yaml files use a consistent code style.
+- [xmllint][] to verify that XML files are well-formed and validated against the applicable XSD file.
 
 These tools are also run as [GitHub actions][].
 All the checks can be run locally using [`act`][].
@@ -121,6 +122,7 @@ is written in. For details please consult the relevant tool's documentation.
 [jsonlint]: https://www.npmjs.com/package/jsonlint
 [remark-lint]: https://www.npmjs.com/package/remark-lint
 [yamllint]: https://yamllint.readthedocs.io/en/stable/
+[xmllint]: https://gnome.pages.gitlab.gnome.org/libxml2/xmllint.html
 [`act`]: https://github.com/nektos/act
 
 ## Release process


### PR DESCRIPTION
## Proposed Changes

The `phpcsstandards/xmllint-validate` action runner can validate XML files for both well-formedness, as well as validating the XML against an XSD schema.

This commit adds a new lint job to the `linting` workflow to take advantage of that to validate:
* Dev tool config files against their applicable XSD files.
* PHPCS rulesets used in the tests against the PHPCS XSD ruleset.

Ref: https://github.com/marketplace/actions/xmllint-validate


## Suggested changelog entry
_N/A_