### PR TITLE
Yamllint: update config to fix (ignore) warnings

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -1,3 +1,4 @@
+---
 name: Check PRs for merge conflicts
 
 on:

--- a/.yamllint
+++ b/.yamllint
@@ -6,3 +6,5 @@ rules:
     level: warning
     max: 120
   truthy: {allowed-values: ["true", "false", "on"]}
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
## Proposed Changes

Yamllint 1.37.1 introduced a new check which check the number of spaces between the Yaml and trailing comments on the same line.

In their wisdom, they have elected to make the expected number of spaces default to `2`, while we use `1` in practice.

This commit updates the configuration to check for 1 space instead of 2.

Ref:
* https://github.com/adrienverge/yamllint/blob/master/CHANGELOG.rst#1371-2025-05-04
* https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.comments


## Suggested changelog entry
_N/A_