### PR TITLE
Drop support for PHP < 7.2

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -26,11 +26,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '5.4'
-          - '5.5'
-          - '5.6'
-          - '7.0'
-          - '7.1'
           - '7.2'
           - '7.3'
           - '7.4'
@@ -43,67 +38,24 @@ jobs:
           - '8.6'
         composer:
           - 'v2'
+          - '2.2'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
 
         exclude:
-          # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
-          # Considering PHP 5.4 is ancient, I deem it acceptable to exclude the Windows PHP 5.4 builds.
-          # @link https://github.com/PHPCSStandards/composer-installer/pull/213
-          - php: '5.4'
-            os: 'windows-latest'
+          # Composer 2.3 drops support for PHP < 7.2, so `v2` will install Composer >= 2.3.
+          # The current matrix is set up to safeguard that the Composer 2.2 LTS version is 100% supported for PHP 7.2-8.3.
+          # Note: Composer 2.2 is not compatible with PHP >= 8.4 and it is unlikely that it will be
+          # made compatible with PHP >= 8.4, so we need to exclude those builds.
+          - php: '8.4'
+            composer: '2.2'
+          - php: '8.5'
+            composer: '2.2'
+          - php: '8.6'
+            composer: '2.2'
 
         include:
-          # Composer 2.3 drops support for PHP < 7.2, so for PHP 5.4 to 7.1, `v2` will install
-          # Composer 2.2, for PHP 7.2 and up, `v2` will install Composer >= 2.3.
-          # These builds make sure the Composer 2.2 LTS version is 100% supported for PHP 7.2-8.3.
-          # Note: Composer 2.2 is not compatible with PHP 8.4 and it is unlikely that it will be
-          # made compatible with PHP 8.4.
-          - php: '7.2'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '7.3'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '7.4'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '8.0'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '8.1'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '8.2'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-          - php: '8.3'
-            composer: '2.2'
-            os: 'ubuntu-latest'
-
-          - php: '7.2'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '7.3'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '7.4'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '8.0'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '8.1'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '8.2'
-            composer: '2.2'
-            os: 'windows-latest'
-          - php: '8.3'
-            composer: '2.2'
-            os: 'windows-latest'
-
           # Also test against the dev version of Composer for early warning about upcoming changes.
           - php: 'latest'
             composer: 'snapshot'

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.6', '7.2', 'latest', 'nightly']
+        php: ['7.2', 'latest', 'nightly']
 
     continue-on-error: ${{ matrix.php == 'nightly' }}
 

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -28,27 +28,13 @@ jobs:
     strategy:
       matrix:
         php:
-          - '5.4'
           - '7.2'
           - 'latest'
         composer:
-          # Note: for PHP 5.4 - 7.1, "v2" will install Composer 2.2.
-          # For PHP 7.2+, it will install Composer "latest".
           - 'v2'
         os:
           - 'ubuntu-latest'
           - 'windows-latest'
-
-        # Installing on Windows with PHP 5.4 runs into all sorts of problems (which are not ours).
-        # Exclude the Windows PHP 5.4 builds and replace them with PHP 5.5 for the same.
-        # @link https://github.com/PHPCSStandards/composer-installer/issues/181
-        # @link https://github.com/PHPCSStandards/composer-installer/pull/213
-        exclude:
-          - php: '5.4'
-            os: 'windows-latest'
-        include:
-          - php: '5.5'
-            os: 'windows-latest'
 
     name: "Quick test"
 

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4']
+        php: ['7.2', 'latest']
 
     steps:
       - name: Checkout code
@@ -47,12 +47,5 @@ jobs:
           # Ignore development-only packages in security check
           composer-options: "--no-dev"
 
-      - name: Download security checker
-        # yamllint disable-line rule:line-length
-        run: wget -P . https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.6/local-php-security-checker_2.0.6_linux_amd64
-
-      - name: Make security checker executable
-        run: chmod +x ./local-php-security-checker_2.0.6_linux_amd64
-
       - name: Check against insecure dependencies
-        run: ./local-php-security-checker_2.0.6_linux_amd64 --path=vendor/composer/installed.json
+        run: composer audit --abandoned=fail

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,11 @@ These tools fall into two categories: PHP and non-PHP.
 
 The PHP specific tools used by this build are:
 
+- [Composer][] to install dependencies.
 - [PHPUnit][] and the [PHPUnit Polyfills][] for the integration tests.
 - [PHP_CodeSniffer][] to verify PHP code complies with the [PSR12][] standard.
 - [PHPCompatibility][] to verify that code is written in a PHP cross-version compatible manner.
 - [PHP-Parallel-Lint][] to check against parse errors in PHP files.
-- [PHP-Security-Checker][] to prevent insecure dependencies being installed.
 
 The automated checks with these tools are run via [GitHub Actions][].
 
@@ -54,28 +54,24 @@ run locally with PHP.
 
 For the Parallel Lint check, the `composer lint` script has been added for convenience.
 
-The Security Checker package is not included in the Composer configuration. An executable
-can be downloaded suitable for your operating system from their [releases page][].
-
 Alternatively, these tools can be run using `docker run`, through the Docker
 images provided by [Pipeline-Component][].
 
+[Composer]: https://getcomposer.org/
 [PHPUnit]: https://phpunit.de/
 [PHPUnit Polyfills]: https://github.com/Yoast/PHPUnit-Polyfills/
 [PHP_CodeSniffer]: https://github.com/PHPCSStandards/PHP_CodeSniffer
 [PHPCompatibility]: https://github.com/PHPCompatibility/PHPCompatibility
 [PHP-Parallel-Lint]: https://github.com/php-parallel-lint/PHP-Parallel-Lint
-[PHP-Security-Checker]: https://github.com/fabpot/local-php-security-checker
 [PSR12]: https://www.php-fig.org/psr/psr-12/
-[releases page]: https://github.com/fabpot/local-php-security-checker/releases/
 
 #### Automated testing
 
 This package includes a test setup for automated testing on all supported PHP versions
 using [PHPUnit][] with the [PHPUnit Polyfills][].
-This means that tests can be written for the latest version of PHPUnit
+This means that tests can be written for the highest supported version of PHPUnit
 (9.x at the time of writing) and still be run on all PHPUnit versions needed to test
-all supported PHP versions (PHPUnit 4.x - 9.x).
+all supported PHP versions (PHPUnit 8.x - 9.x).
 
 The tests can be run both via a Composer installed version of PHPUnit, as well as using
 a PHPUnit PHAR file, however, whichever way you run the tests, you will always need to

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ That's it.
 
 This plugin is compatible with:
 
-- PHP **5.4+**, **7.x**, and **8.x** (Support for PHP v8 is available since [`v0.7.0`][v0.7])
-- [Composer][composer] **2.2+** (Support for Composer v2 is available since [`v0.7.0`][v0.7]; support for Composer < 2.2 was dropped in [`v1.1.0`][v1.1])
-- [PHP_CodeSniffer][codesniffer] **3.x** and **4.x**(Support for PHP_CodeSniffer v4 is available since [`v0.7.0`][v0.7], support for PHP_CodeSniffer v2 was dropped in [`v1.2.0`][v1.2])
+- PHP **7.2**, and **8.x** _(Support for PHP v8 is available since [`v0.7.0`][v0.7], support for PHP < 7.2 was dropped in [`v1.3.0`][v1.3])_
+- [Composer][composer] **2.2+** _(Support for Composer v2 is available since [`v0.7.0`][v0.7]; support for Composer < 2.2 was dropped in [`v1.1.0`][v1.1])_
+- [PHP_CodeSniffer][codesniffer] **3.x** and **4.x** _(Support for PHP_CodeSniffer v4 is available since [`v0.7.0`][v0.7], support for PHP_CodeSniffer v2 was dropped in [`v1.2.0`][v1.2])_
 
 ### How it works
 
@@ -162,8 +162,8 @@ Create a composer package of your coding standard by adding a `composer.json` fi
   "name" : "acme/phpcodesniffer-our-standards",
   "description" : "Package contains all coding standards of the Acme company",
   "require" : {
-    "php" : ">=5.4.0",
-    "squizlabs/php_codesniffer" : "^3.13"
+    "php" : ">=7.2.0",
+    "squizlabs/php_codesniffer" : "^4.0"
   },
   "type" : "phpcodesniffer-standard"
 }
@@ -276,3 +276,4 @@ THE SOFTWARE.
 [v0.7]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v0.7.0
 [v1.1]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.1.0
 [v1.2]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.2.0
+[v1.3]: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.3.0

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "security": "https://github.com/PHPCSStandards/composer-installer/security/policy"
   },
   "require": {
-    "php": ">=5.4",
+    "php": ">=7.2",
     "composer-plugin-api": "^2.2",
     "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
   },

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,7 +14,7 @@
     <exclude-pattern>*/vendor/*</exclude-pattern>
 
     <rule ref="PHPCompatibility"/>
-    <config name="testVersion" value="5.4-"/>
+    <config name="testVersion" value="7.2-"/>
 
     <rule ref="PSR12">
         <!-- Constant visibility can not be declared (yet) as the minimum supported PHP version is 5.4

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,11 +16,7 @@
     <rule ref="PHPCompatibility"/>
     <config name="testVersion" value="7.2-"/>
 
-    <rule ref="PSR12">
-        <!-- Constant visibility can not be declared (yet) as the minimum supported PHP version is 5.4
-             and constant visibility was only introduced in PHP 7.1. -->
-        <exclude name="PSR12.Properties.ConstantVisibility.NotFound"/>
-    </rule>
+    <rule ref="PSR12"/>
 
     <rule ref="Generic.Formatting.MultipleStatementAlignment">
         <properties>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
     backupGlobals="false"
     bootstrap="./tests/bootstrap.php"
     beStrictAboutTestsThatDoNotTestAnything="true"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,23 +34,23 @@ use Symfony\Component\Process\PhpExecutableFinder;
  */
 class Plugin implements PluginInterface, EventSubscriberInterface
 {
-    const KEY_MAX_DEPTH = 'phpcodesniffer-search-depth';
+    public const KEY_MAX_DEPTH = 'phpcodesniffer-search-depth';
 
-    const MESSAGE_ERROR_WRONG_MAX_DEPTH =
+    public const MESSAGE_ERROR_WRONG_MAX_DEPTH =
         'The value of "%s" (in the composer.json "extra".section) must be an integer larger than %d, %s given.';
 
-    const MESSAGE_NOT_INSTALLED      = 'PHPCodeSniffer is not installed';
-    const MESSAGE_NOTHING_TO_INSTALL = 'No PHPCS standards to install or update';
-    const MESSAGE_PLUGIN_UNINSTALLED = 'PHPCodeSniffer Composer Installer is uninstalled';
-    const MESSAGE_RUNNING_INSTALLER  = 'Running PHPCodeSniffer Composer Installer';
+    public const MESSAGE_NOT_INSTALLED      = 'PHPCodeSniffer is not installed';
+    public const MESSAGE_NOTHING_TO_INSTALL = 'No PHPCS standards to install or update';
+    public const MESSAGE_PLUGIN_UNINSTALLED = 'PHPCodeSniffer Composer Installer is uninstalled';
+    public const MESSAGE_RUNNING_INSTALLER  = 'Running PHPCodeSniffer Composer Installer';
 
-    const PACKAGE_NAME = 'squizlabs/php_codesniffer';
-    const PACKAGE_TYPE = 'phpcodesniffer-standard';
+    public const PACKAGE_NAME = 'squizlabs/php_codesniffer';
+    public const PACKAGE_TYPE = 'phpcodesniffer-standard';
 
-    const PHPCS_CONFIG_REGEX = '`%s:[^\r\n]+`';
-    const PHPCS_CONFIG_KEY   = 'installed_paths';
+    public const PHPCS_CONFIG_REGEX = '`%s:[^\r\n]+`';
+    public const PHPCS_CONFIG_KEY   = 'installed_paths';
 
-    const PLUGIN_NAME = 'dealerdirect/phpcodesniffer-composer-installer';
+    public const PLUGIN_NAME = 'dealerdirect/phpcodesniffer-composer-installer';
 
     /**
      * @var Composer

--- a/tests/CreateComposerZipArtifacts.php
+++ b/tests/CreateComposerZipArtifacts.php
@@ -34,7 +34,7 @@ class CreateComposerZipArtifacts
      *
      * @var string
      */
-    const FIXTURE_VERSION = '1.0.0';
+    private const FIXTURE_VERSION = '1.0.0';
 
     /**
      * The full path to the directory to place the zipped artifacts in (including trailing slash).

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -22,14 +22,14 @@ final class PHPCSVersions
      *
      * @var string
      */
-    const MASTER = '4.x-dev';
+    private const MASTER = '4.x-dev';
 
     /**
      * Composer name for the development branch for the next major.
      *
      * @var string
      */
-    const NEXT_MAJOR = '5.x-dev as 4.99.99';
+    private const NEXT_MAJOR = '5.x-dev as 4.99.99';
 
     /**
      * List of all PHPCS version which are supported by this plugin.

--- a/tests/PHPCSVersions.php
+++ b/tests/PHPCSVersions.php
@@ -334,20 +334,6 @@ final class PHPCSVersions
          * Adjust the list of available versions based on the PHP version on which the tests are run.
          */
         switch (\CLI_PHP_MINOR) {
-            case '5.4':
-            case '5.5':
-            case '5.6':
-            case '7.0':
-            case '7.1':
-                $versions = array_filter(
-                    self::$allPhpcsVersions,
-                    static function ($version) {
-                        // PHPCS 3.x is the last version still supporting PHP < 7.2.
-                        return version_compare($version, '3.99.99', '<=');
-                    }
-                );
-                break;
-
             case '7.2':
                 $versions = self::$allPhpcsVersions;
                 break;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -340,7 +340,7 @@ abstract class TestCase extends PolyfillTestCase
 
         /*
          * If the command will be run on Windows in combination with PHP < 8.0, wrap it in an extra set of quotes.
-         * Note: it is unclear what changes in PHP 8.0, but the quotes will now suddenly break things.
+         * Note: it is unclear what changed in PHP 8.0, but the quotes will now suddenly break things.
          * Ref: https://www.php.net/manual/en/function.proc-open.php#example-3331
          */
         if (static::onWindows() === true && substr(\CLI_PHP_MINOR, 0, 1) < 8) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,7 +29,7 @@ abstract class TestCase extends PolyfillTestCase
     public static function createTestEnvironment()
     {
         // Make temp directory
-        $class           = substr(strrchr(get_called_class(), '\\'), 1);
+        $class           = substr(strrchr(static::class, '\\'), 1);
         static::$tempDir = sys_get_temp_dir() . '/PHPCSPluginTest/' . uniqid("{$class}_", true);
 
         $subDirs = array(

--- a/tests/fixtures/dummy-src/composer.json
+++ b/tests/fixtures/dummy-src/composer.json
@@ -4,7 +4,7 @@
     "type" : "phpcodesniffer-standard",
     "license" : "MIT",
     "require" : {
-        "php" : ">=5.4",
+        "php" : ">=7.2",
         "squizlabs/php_codesniffer" : "*",
         "dealerdirect/phpcodesniffer-composer-installer" : "*"
     },

--- a/tests/fixtures/dummy-subdir/composer.json
+++ b/tests/fixtures/dummy-subdir/composer.json
@@ -4,7 +4,7 @@
     "type" : "phpcodesniffer-standard",
     "license" : "MIT",
     "require" : {
-        "php" : ">=5.4",
+        "php" : ">=7.2",
         "squizlabs/php_codesniffer" : "*"
     }
 }

--- a/tests/fixtures/incorrect-type/composer.json
+++ b/tests/fixtures/incorrect-type/composer.json
@@ -4,7 +4,7 @@
     "type" : "coding-standard",
     "license" : "MIT",
     "require" : {
-        "php" : ">=5.4",
+        "php" : ">=7.2",
         "squizlabs/php_codesniffer" : "*",
         "dealerdirect/phpcodesniffer-composer-installer" : "*"
     },


### PR DESCRIPTION
## Proposed Changes

### Drop support for PHP < 7.2 

This commit comprehensively drops support for PHP < 7.2.

Includes changing the security workflow to use the Composer `audit` command instead of the deprecated security checker CLI tool.

**Note:** this commit does not change the supported PHPUnit versions (other than no longer needing PHPUnit 4.x - 7.x).
This could possibly be done in a follow-up ticket, but to support PHPUnit >= 10, we'll need to find another way to debug failing tests as the test listener implementation we currently use, is no longer supported on PHPUnit >= 10.

Closes #221

### Modernize: add constant visibility 

For the tests, all visibility modifiers have been set to `private`.
For the `src`, all visibility modifiers have been set to `public` as anything else could be considered a BC-break.

I suggest we open a ticket to change the constant visibility for the class constants in the `Plugin` class to `private` in the next major.

### Modernize: use ::class

## Suggested changelog entry
Removed: Support for PHP < 7.2