### PR TITLE
Tests: ignore security advisories for PHP_CodeSniffer

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -252,6 +252,24 @@ abstract class TestCase extends PolyfillTestCase
             $config['config']['allow-plugins']['dealerdirect/phpcodesniffer-composer-installer'] = true;
         }
 
+        // Inject ignoring of security advisories for PHP_CodeSniffer to allow for testing against
+        // older versions of dependencies, which may contain security vulnerabilities
+        // (like PHP_CodeSniffer < 3.13.6 and < 4.0.2).
+        if (
+            version_compare(\COMPOSER_VERSION, '2.10.0', '>=') === true
+            && isset($config['config']['policy']['advisories']['ignore']) === false
+            && isset($config['config']['audit']['ignore']) === false
+        ) {
+            $config['config']['policy']['advisories']['ignore'] = ['squizlabs/php_codesniffer'];
+        }
+
+        if (
+            version_compare(\COMPOSER_VERSION, '2.9.0', '>=') === true
+            && isset($config['config']['audit']['ignore']) === false
+        ) {
+            $config['config']['audit']['ignore'] = ['squizlabs/php_codesniffer'];
+        }
+
         $encoded = json_encode($config, \JSON_UNESCAPED_SLASHES | \JSON_PRETTY_PRINT);
         if (json_last_error() !== \JSON_ERROR_NONE || $encoded === false) {
             throw new RuntimeException('Provided configuration can not be encoded to valid JSON');


### PR DESCRIPTION
## Proposed Changes

PHP_CodeSniffer has recently released a security fix via the 3.13.6 and 4.0.2 releases. This fix only affects the `*blame` report formats, so has no impact on the functionality in this Composer plugin.

While end-users _should_, of course, be encouraged to use a secure version of PHP_CodeSniffer, it is not for this package to enforce this, so this package should continue to support a wide range of PHPCS versions.

As this project itself does (deliberately) not use a `composer.lock` file, installation of the project in CI/GHA should not run into problems as Composer will automatically install the latest/safe PHPCS releases.

However, the test suite runs `composer install` with varying versions of PHP_CodeSniffer to safeguard compatibility with all supported versions and that will now run into trouble when `composer install` is run from within the test suite with Composer 2.9 or higher.

For the record:
* Composer 2.4 introduced a `composer audit` command which didn't block anything, but could "audit" whether a package required vulnerable dependencies.
* As of Composer 2.9, Composer blocks the installation of vulnerable dependencies by default. This could be turned off or selectively ignored via `config.audit` settings.
* As of Composer 2.10, the `config.audit` settings are deprecated and replaced with `config.policy` settings.

This commit takes the above into account and will - conditionally - inject the appropriate setting into any `composer.json` files being created for use in the tests.

Notes:
* The `config.audit`/`config.policy.advisories` settings allow for selectively ignoring specific advisories. I've elected **not** to limit the `ignore`s to the advisories related to the current PHPCS vulnerabilities, but to accept any vulnerable PHPCS version as we need to allow them all for the purpose of testing.
* I've also considered turning off the Composer blocking of vulnerable package completely. I ended up deciding against that to prevent potential new tests introducing a security event for **_this_** package (as CI will run on unmerged PRs from potentially untrusted contributors).

For the record, for the current PHPCS vulnerabilities, we would have had to ignore the following two advisory IDs:
* `GHSA-hmqg-cxww-wqhq` (official advisory published via GitHub and attached to CVE-2026-67434)
* `PKSA-rdkp-vv9z-mjkg` (unofficial advisory published via Packagist)

Refs:
* https://blog.packagist.com/composer-2-4/#auditing-dependencies-for-known-security-vulnerabilities
* https://blog.packagist.com/composer-2-9/#automatic-security-blocking
* https://blog.packagist.com/composer-2-10-release/#dependency-policy-configuration
* https://github.com/advisories/GHSA-hmqg-cxww-wqhq
* https://packagist.org/security-advisories/PKSA-rdkp-vv9z-mjkg


## Suggested changelog entry
_N/A_