### PR TITLE
GH Actions: set permissions for each workflow/job

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -19,8 +19,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: "${{ matrix.os }}"
 
     strategy:

--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -13,12 +13,18 @@ on:
       - synchronize
       - reopened
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   check-prs:
-    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # To add and remove PR labels.
+
     if: github.repository_owner == 'PHPCSStandards'
 
     name: Check PRs for merge conflicts
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check PRs for merge conflicts

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -12,8 +12,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   validate-composer:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,6 +31,9 @@ jobs:
           args: "composer validate --no-check-lock"
 
   lint-json:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -36,6 +45,9 @@ jobs:
           args: "find . -not -path './.git/*' -name '*.json' -type f -exec jsonlint --quiet {} ;"
 
   yamllint:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -45,6 +57,9 @@ jobs:
         uses: pipeline-components/yamllint@master
 
   php-codesniffer:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -54,6 +69,9 @@ jobs:
         uses: pipeline-components/php-codesniffer@master
 
   lint-remark:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,6 +81,9 @@ jobs:
         uses: pipeline-components/remark-lint@master
 
   lint-xml:
+    permissions:
+      contents: read # To clone the repo.
+
     name: Check XML files
     runs-on: ubuntu-latest
 

--- a/.github/workflows/phplint.yml
+++ b/.github/workflows/phplint.yml
@@ -16,8 +16,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phplint:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/quicktest.yml
+++ b/.github/workflows/quicktest.yml
@@ -18,11 +18,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   #### QUICK TEST STAGE ####
   # This is a much quicker test which only runs the integration tests against a limited set of
   # supported PHP/PHPCS combinations.
   quicktest:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: "${{ matrix.os }}"
 
     strategy:

--- a/.github/workflows/securitycheck.yml
+++ b/.github/workflows/securitycheck.yml
@@ -16,8 +16,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   security-check:
+    permissions:
+      contents: read # To clone the repo.
+
     runs-on: ubuntu-latest
     name: "Security check"
 


### PR DESCRIPTION
## Proposed Changes

> Users frequently over-scope their workflow and job permissions, or set broad workflow-level permissions without realizing that all jobs inherit those permissions.
>
> Furthermore, users often don't realize that the _default_ `GITHUB_TOKEN` permissions can be very broad, meaning that workflows that don't configure any permissions at all can _still_ provide excessive credentials to their individual jobs.
>
> **Remediation**
> In general, permissions should be declared as minimally as possible, and as close to their usage site as possible.
>
> In practice, this means that workflows should almost always set `permissions: {}` at the workflow level to disable all permissions by default, and then set specific job-level permissions as needed.

Refs:
* https://docs.zizmor.sh/audits/#excessive-permissions

## Suggested changelog entry
_N/A_